### PR TITLE
avoid using deprecated @pipeline macro

### DIFF
--- a/_literate/A-composing-models/Manifest.toml
+++ b/_literate/A-composing-models/Manifest.toml
@@ -121,9 +121,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[deps.Distributions]]
 deps = ["ChainRulesCore", "DensityInterface", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns", "Test"]
-git-tree-sha1 = "6a8dc9f82e5ce28279b6e3e2cea9421154f5bd0d"
+git-tree-sha1 = "97e9e9d0b8303bae296f3bdd1c2b0065dcb7e7ef"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.37"
+version = "0.25.38"
 
 [[deps.DocStringExtensions]]
 deps = ["LibGit2"]

--- a/_literate/A-composing-models/tutorial.jl
+++ b/_literate/A-composing-models/tutorial.jl
@@ -29,27 +29,36 @@ scitype(X.age)
 
 # A typical workflow for such data is to one-hot-encode the categorical data and then apply some regression model on the data.
 # Let's say that we want to apply the following steps:
-# 1. standardize the target variable (`:height`)
-# 1. one hot encode the categorical data
-# 1. train a KNN regression model
+# 1. One hot encode the categorical features in `X`
+# 1. Standardize the target variable (`:height`)
+# 1. Train a KNN regression model on the one hot encoded data and the Standardized target.
 
-# The `@pipeline` macro helps you define such a simple (non-branching) pipeline of steps to be applied in order:
+# The `Pipeline` constructor helps you define such a simple (non-branching) pipeline of steps to be applied in order:
 
-pipe = @pipeline(
-    X -> coerce(X, :age=>Continuous),
-    OneHotEncoder(),
-    KNNRegressor(K=3),
-    target = UnivariateStandardizer());
+pipe = Pipeline(
+    coercer = X -> coerce(X, :age=>Continuous),
+    one_hot_encoder = OneHotEncoder(),
+    transformed_target_model = TransformedTargetModel(
+        model = KNNRegressor(K=3);
+        target=UnivariateStandardizer()
+    )
+)
 
 # Note the coercion of the `:age` variable to Continuous since `KNNRegressor` expects `Continuous` input.
-# Note also the `target` keyword where you can specify a transformation of the target variable.
+# Note also the `TransformedTargetModel` which allows one to learn a transformation (in this case Standardization) of the 
+# target variable to be passed to the `KNNRegressor`.
 
 # Hyperparameters of this pipeline can be accessed (and set) using dot syntax:
 
-pipe.knn_regressor.K = 2
+pipe.transformed_target_model.model.K = 2
 pipe.one_hot_encoder.drop_last = true;
 
 # Evaluation for a pipe can be done with the `evaluate!` method; implicitly it will construct machines that will contain the fitted parameters etc:
 
-evaluate(pipe, X, height, resampling=Holdout(),
-         measure=rms) |> pprint
+evaluate(
+    pipe,
+    X,
+    height,
+    resampling=Holdout(),
+    measure=rms
+) |> pprint


### PR DESCRIPTION
Re-write the model composition tutorial removing references to the deprecated `@pipleline` macro.
cc. @tlienart 