### PR TITLE
Tweak instructions for activating an environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Once all that's done, the remaining things to do are to create the HTML page and
 
 * you have a PR with changes, someone has reviewed them and they got merged into the main branch
 
+* Be sure the version of Julia declared near the top of `index.md`
+  matches the version used to generate the web-site (which should
+  match the version declared in each tutorial's Manifest.toml file)
+
+
 **Once the changes are in the main branch**:
 
 * run `cd("path/to/DataScienceTutorials"); using Franklin` to launch Franklin

--- a/config.md
+++ b/config.md
@@ -50,8 +50,7 @@ ignore = [
 
 
 \newcommand{\tutorial}[1]{
-  *Download the \nblink{!#1}, the \sclink{!#1} or the \rawlink{!#1} for this tutorial (right-click on the relevant link and save-as). These rely on [this Project.toml](\proj{!#1}) and [this Manifest.toml](\mani{!#1}).* \\
-  *You can also download the whole [project folder](\tgz{#1}).*
+  *To ensure code in this tutorial runs as shown, download the tutorial [project folder](\tgz{#1}) and follow [these instructions](/#learning_by_doing).*
 
   *If you have questions or suggestions about this tutorial, please open an issue [here](https://github.com/JuliaAI/DataScienceTutorials.jl/issues/new).*
 

--- a/deploy.jl
+++ b/deploy.jl
@@ -16,20 +16,20 @@ Logging.disable_logging(Logging.LogLevel(1500))
 genpath = "__site"/"__generated"
 isdir(genpath) || mkpath(genpath)
 
+
+const LINK_INSTRUCTIONS =
+    "https://juliaai.github.io/DataScienceTutorials.jl/#learning_by_doing"
+
 LINK(dir, f) = "https://raw.githubusercontent.com/" *
                "juliaai/DataScienceTutorials.jl/gh-pages/__generated/" *
                "$(dir)/$(f)"
 
 ACTIVATE(dir) = """
     # Before running this, please make sure to activate and instantiate the
-    # environment with [this `Project.toml`]($(LINK(dir, "Project.toml"))) and
-    # [this `Manifest.toml`]($(LINK(dir, "Manifest.toml"))).
-    # For instance, copy these files to a folder '$dir', `cd` to it and
-    #
-    # ```julia
-    # using Pkg; Pkg.activate("."); Pkg.instantiate()
-    # ```
-
+    # tutorial-specific package environment, using this
+    # [`Project.toml`]($(LINK(dir, "Project.toml"))) and
+    # [this `Manifest.toml`]($(LINK(dir, "Manifest.toml"))), or by following
+    # [these]($LINK_INSTRUCTIONS) detailed instructions.
     """
 
  function pre_process_script(io, s)

--- a/index.md
+++ b/index.md
@@ -2,23 +2,37 @@
 
 ## Learning by doing
 
-This website offers tutorials for [MLJ.jl](https://github.com/alan-turing-institute/MLJ.jl) and related packages.
-On each tutorial page, you will find a link to download the raw script and the notebook corresponding to the page.
+This website offers tutorials for [MLJ.jl](https://github.com/alan-turing-institute/MLJ.jl) and related packages. 
 
-Feedback and PRs are always welcome to help make these tutorials better, from the presentation to the content.
+**The code included on each tutorial page will only work reliably if:**
 
-In order to reproduce the environment that was used to generate each tutorials, please follow these steps:
-1. Go to the directory of your choice: `cd("/Users/[JohnDoe]/")`
-2. Create a folder named, e.g., "MLJ\_tutorials": `mkdir("MLJ_tutorials")`
-3. Download the tutorial `Project.toml` (available at the top of the tutorial) as well as the `Manifest.toml` in this folder;
-4. In the folder, do
 
-```julia-repl
-julia> using Pkg; Pkg.activate("."); Pkg.instantiate();
-```
+- You are running Julia 1.7.x where "x" is any integer (to check, enter
+  `VERSION` at the REPL); and
 
-The tutorials are run with the [latest stable release](https://julialang.org/downloads/#current_stable_release) of Julia, if you use a nightly version or an old version, you might encounter issues.
-In such cases, please open a PR so we can investigate.
+- You have activated the package environment associated with that package.
+
+The environment is encoded in files called `Project.toml` and
+`Manifest.toml` linked at the top of each tutorial. However, we
+recommend new Julia users follow these simple steps to activate the
+environment:
+
+1. Download and decompress the "whole project" folder that is linked near the top of the tutorial. 
+2. Launch Julia and enter `using Pkg; Pkg.activate("Path/To/Decompressed/Folder")`. 
+
+The folder you downloaded also contains the raw script, annotated
+script and Jupyter notebook versions of the tutorial, now ready to use. 
+
+
+## Having problems?
+
+Please report issues
+[here](https://github.com/JuliaAI/DataScienceTutorials.jl/issues). For
+beginners, the most common issues arise because of an incorrect
+version of Julia, or because of an incorrect package environment. So
+be sure you have followed the instructions above before raising an
+issue. 
+
 
 ## Elementary data manipulations
 

--- a/index.md
+++ b/index.md
@@ -41,9 +41,10 @@ to be installed and precompiled.
 ### Running the provided Juptyer notebook
 
 The downloaded project folder contains a Juptyer notebook called
-`tutorial.ipynb`. See the [IJulia documentation]() on how to launch
-it. Copy and execute the code fragment above in a new notebook
-cell before evaluating any other cells.
+`tutorial.ipynb`. See the [IJulia
+documentation](https://julialang.github.io/IJulia.jl/stable/manual/running/)
+on how to launch it. Copy and execute the code fragment above in a new
+notebook cell before evaluating any other cells.
 
 ### Running the provided Julia script line-by-line from an IDE
 

--- a/index.md
+++ b/index.md
@@ -4,18 +4,18 @@
 
 This website offers tutorials for [MLJ.jl](https://github.com/alan-turing-institute/MLJ.jl) and related packages. 
 
-**The code included on each tutorial page will only work reliably if:**
-
+The code included on each tutorial is only tested to work reliably
+under these conditions:
 
 - You are running Julia 1.7.x where "x" is any integer (to check, enter
   `VERSION` at the REPL); and
 
-- You have activated the package environment associated with that package.
+- You have activated the package environment associated with that tutorial.
 
 The environment is encoded in files called `Project.toml` and
 `Manifest.toml` linked at the top of each tutorial. However, we
 recommend new Julia users follow these simple steps to activate the
-environment:
+environment (before pasting the code into the REPL, for example):
 
 1. Download and decompress the "whole project" folder that is linked near the top of the tutorial. 
 2. Launch Julia and enter `using Pkg; Pkg.activate("Path/To/Decompressed/Folder")`. 
@@ -23,7 +23,7 @@ environment:
 The folder you downloaded also contains the raw script, annotated
 script and Jupyter notebook versions of the tutorial, now ready to use. 
 
-For more on package management in Julia, go
+For more on package management in Julia, see
 [here](https://docs.julialang.org/en/v1/stdlib/Pkg/).
 
 

--- a/index.md
+++ b/index.md
@@ -23,6 +23,9 @@ environment:
 The folder you downloaded also contains the raw script, annotated
 script and Jupyter notebook versions of the tutorial, now ready to use. 
 
+For more on package management in Julia, go
+[here](https://docs.julialang.org/en/v1/stdlib/Pkg/).
+
 
 ## Having problems?
 

--- a/index.md
+++ b/index.md
@@ -4,37 +4,67 @@
 
 This website offers tutorials for [MLJ.jl](https://github.com/alan-turing-institute/MLJ.jl) and related packages. 
 
-The code included on each tutorial is only tested to work reliably
-under these conditions:
+The code included on each tutorial is tested to work reliably
+under these two conditions:
 
 - You are running Julia 1.7.x where "x" is any integer (to check, enter
-  `VERSION` at the REPL); and
+  `VERSION` at the REPL).
 
-- You have activated the package environment associated with that tutorial.
+- You have activated and instantiated the associated [package
+  environment](https://docs.julialang.org/en/v1/stdlib/Pkg/).
 
-The environment is encoded in files called `Project.toml` and
-`Manifest.toml` linked at the top of each tutorial. However, we
-recommend new Julia users follow these simple steps to activate the
-environment (before pasting the code into the REPL, for example):
+To make the tutorial-specific environment available to you, first download (and
+decompress) the "project folder" that is linked near the top of the
+tutorial. How you proceed next depends on your chosen mode of interaction:
 
-1. Download (and decompress if necessary) the "whole project folder" that is linked near the top of the tutorial. 
-2. Launch Julia and enter `using Pkg; Pkg.activate("Path/To/Whole/Project/Folder"))`. 
 
-The folder you downloaded also contains the raw script, annotated
-script and Jupyter notebook versions of the tutorial, now ready to use. 
+### Pasting code copied from web page directly into the Julia REPL
 
-For more on package management in Julia, see
-[here](https://docs.julialang.org/en/v1/stdlib/Pkg/).
+Recommended for new Julia users.
 
+Activate and instantiate the correct environment by entering this code
+at the `julia> ` prompt:
+
+```julia
+using Pkg; Pkg.activate("Path/To/Project/Folder"); Pkg.instantiate()
+```
+
+You need to replace `"Path/To/Project/Folder"` with the actual path to
+the downloaded project folder.  This can be just `"."` if Julia has been
+launched from the command-line, with the project folder as the current
+directory.
+
+This might take a few minutes for some tutorials, as packages may need
+to be installed and precompiled.
+
+
+### Running the provided Juptyer notebook
+
+The downloaded project folder contains a Juptyer notebook called
+`tutorial.ipynb`. See the [IJulia documentation]() on how to launch
+it. Copy and execute the code fragment above in a new notebook
+cell before evaluating any other cells.
+
+### Running the provided Julia script line-by-line from an IDE
+
+In your IDE (e.g., VS Code or emacs) open the file called
+`tutorial.jl` in the downloaded project folder and
+activate/instantiate by first running the code fragment given above.
 
 ## Having problems?
 
 Please report issues
 [here](https://github.com/JuliaAI/DataScienceTutorials.jl/issues). For
-beginners, the most common issues arise because of an incorrect
-version of Julia, or because of an incorrect package environment. So
-be sure you have followed the instructions above before raising an
-issue. 
+beginners, the most common issues arise because the Julia version is
+incorrect, or because of an incorrect package environment. So be sure
+you have tried the instructions above before raising an issue.
+
+If you need to use an earlier version of Julia, you can try deleting
+the `Manifest.toml` file contained in the project folder and running
+`using Pkg; Pkg.instantiate()` to generate a new package environment,
+but the exact package versions will be different from those used to
+test the tutorial and generate the output seen on the tutorial web
+page.
 
 
 ## Elementary data manipulations

--- a/index.md
+++ b/index.md
@@ -17,8 +17,8 @@ The environment is encoded in files called `Project.toml` and
 recommend new Julia users follow these simple steps to activate the
 environment (before pasting the code into the REPL, for example):
 
-1. Download and decompress the "whole project" folder that is linked near the top of the tutorial. 
-2. Launch Julia and enter `using Pkg; Pkg.activate("Path/To/Decompressed/Folder")`. 
+1. Download (and decompress if necessary) the "whole project folder" that is linked near the top of the tutorial. 
+2. Launch Julia and enter `using Pkg; Pkg.activate("Path/To/Whole/Project/Folder"))`. 
 
 The folder you downloaded also contains the raw script, annotated
 script and Jupyter notebook versions of the tutorial, now ready to use. 


### PR DESCRIPTION
This PR will close #186. It:

- Makes it explicit on the index page what version of Julia is needed to run the tutorials (and activate the environments) reliably. I've added a reminder for devs in README to update this version when updating the tutorials. [Eventually](#183) these instructions will probably move out to another page, but I've left them on index.md for now. 

- Simplifies but elaborates on the instructions for activating/instantiating the environment by having user download the whole project folder. ~~(I've also removed the instruction to instantiate, as this wrong - we want user to activate the environment used to test the tutorials not generate a new one.~~ 😳 

- Adds a link to Julia's pkg management docs

In addition, I should like to:

-  [x]  Reorganize the standard header of each tutorial somewhat, so that it points to these instructions, and that the focus is on "whole project" not not the separate files. @tlienart I can do that if you tell me where to make the edits.