### PR TITLE
Allow sections in tutorials and sidebar to collapse

### DIFF
--- a/_css/extra.css
+++ b/_css/extra.css
@@ -1,3 +1,8 @@
+.collapse {
+    // to have a section be initially collapsed
+    display: none;
+}
+
 /* Geometry adjustments */
 .franklin-content{
     margin-top: 5em;

--- a/_css/side-menu.css
+++ b/_css/side-menu.css
@@ -86,7 +86,7 @@ appears on the left side of the page.
 
 #menu {
     margin-left: -250px; /* "#menu" width */
-    width: 250px;
+    width: 253px;
     position: fixed;
     top: 0;
     left: 0;

--- a/_layout/foot.html
+++ b/_layout/foot.html
@@ -1,6 +1,8 @@
 <!-- CONTENT ENDS HERE -->
       </div> <!-- end of id=main -->
   </div> <!-- end of id=layout -->
+  <!-- for collapse functionality -->
+  <script src="/libs/collapse/collapse.js"></script>
   <script src="/libs/pure/ui.min.js"></script>
   {{ if hasmath }}
       {{ insert foot_katex.html }}

--- a/_layout/head.html
+++ b/_layout/head.html
@@ -1,21 +1,23 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  {{if hasmath}} {{insert head_katex.html }}     {{end}}
+  {{if hasmath}} {{insert head_katex.html }} {{end}}
   {{if hascode}} {{insert head_highlight.html }} {{end}}
   <link rel="stylesheet" href="/css/franklin.css">
   <link rel="stylesheet" href="/css/pure.css">
   <link rel="stylesheet" href="/css/side-menu.css">
   <link rel="stylesheet" href="/css/extra.css">
   <!-- <link rel="icon" href="/assets/infra/favicon.gif"> -->
-  {{isdef title}} <title>{{fill title}}</title>  {{end}}
+  {{isdef title}} <title>{{fill title}}</title> {{end}}
   <!-- LUNR -->
   <script src="/libs/lunr/lunr.min.js"></script>
   <script src="/libs/lunr/lunr_index.js"></script>
   <script src="/libs/lunr/lunrclient.min.js"></script>
 </head>
+
 <body>
   <div id="layout">
     <!-- Menu toggle / hamburger icon -->
@@ -28,70 +30,142 @@
             <p><strong>Data Science Tutorials</strong></p>
           </div>
         </a>
-        <form id="lunrSearchForm" name="lunrSearchForm">
-          <input class="search-input" name="q" placeholder="Enter search term" type="text">
-          <input type="submit" value="Search" formaction="/search/index.html" style="visibility:hidden">
-        </form>
-  <!-- LIST OF MENU ITEMS -->
-  <ul class="pure-menu-list">
-    <li class="pure-menu-item pure-menu-top-item {{ispage index.html}}pure-menu-selected{{end}}"><a href="/" class="pure-menu-link"><strong>Home</strong></a></li>
+          <form id="lunrSearchForm" name="lunrSearchForm">
+            <input class="search-input" name="q" placeholder="Enter search term" type="text">
+            <input type="submit" value="Search" formaction="/search/index.html" style="display:none">
+          </form>
+        <!-- LIST OF MENU ITEMS -->
+        <ul class="pure-menu-list">
+          <li class="pure-menu-item pure-menu-top-item {{ispage index.html}}pure-menu-selected{{end}}"><a href="/"
+              class="pure-menu-link"><strong>Home</strong></a></li>
 
-    <!-- DATA BASICS -->
-    <li class="pure-menu-sublist-title"><strong>Data basics</strong></li>
-    <ul class="pure-menu-sublist">
-      <li class="pure-menu-item {{ispage /data/loading/index.html}}pure-menu-selected{{end}}"><a href="/data/loading/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Loading data</a></li>
-      <li class="pure-menu-item {{ispage /data/dataframe/index.html}}pure-menu-selected{{end}}"><a href="/data/dataframe/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Data Frames</a></li>
-      <li class="pure-menu-item {{ispage /data/categorical/index.html}}pure-menu-selected{{end}}"><a href="/data/categorical/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Categorical Arrays</a></li>
-      <li class="pure-menu-item {{ispage /data/scitype/index.html}}pure-menu-selected{{end}}"><a href="/data/scitype/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Scientific Type</a></li>
-      <li class="pure-menu-item {{ispage /data/processing/index.html}}pure-menu-selected{{end}}"><a href="/data/processing/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Data processing</a></li>
-    </ul>
+          <!-- DATA BASICS -->
+          <div class="dropdown">
+            <li class="pure-menu-sublist-title"><strong>Data basics</strong></li>
+          </div>
+          <div class="collapse dropdown-content">
+            <ul class="pure-menu-sublist">
+              <li class="pure-menu-item {{ispage /data/loading/index.html}}pure-menu-selected{{end}}"><a
+                  href="/data/loading/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Loading
+                  data</a></li>
+              <li class="pure-menu-item {{ispage /data/dataframe/index.html}}pure-menu-selected{{end}}"><a
+                  href="/data/dataframe/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Data
+                  Frames</a></li>
+              <li class="pure-menu-item {{ispage /data/categorical/index.html}}pure-menu-selected{{end}}"><a
+                  href="/data/categorical/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span>
+                  Categorical Arrays</a></li>
+              <li class="pure-menu-item {{ispage /data/scitype/index.html}}pure-menu-selected{{end}}"><a
+                  href="/data/scitype/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Scientific
+                  Type</a></li>
+              <li class="pure-menu-item {{ispage /data/processing/index.html}}pure-menu-selected{{end}}"><a
+                  href="/data/processing/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Data
+                  processing</a></li>
+            </ul>
+          </div>
 
-    <!-- GETTING STARTED WITH MLJ -->
-    <li class="pure-menu-sublist-title"><strong>Getting started</strong></li>
-    <ul class="pure-menu-sublist">
-      <li class="pure-menu-item {{ispage /getting-started/choosing-a-model/index.html}}pure-menu-selected{{end}}"><a href="/getting-started/choosing-a-model/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Choosing a model</a></li>
-      <li class="pure-menu-item {{ispage getting-started/fit-and-predict/index.html}}pure-menu-selected{{end}}"><a href="/getting-started/fit-and-predict/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Fit, predict, transform</a></li>
-      <li class="pure-menu-item {{ispage getting-started/model-tuning/index.html}}pure-menu-selected{{end}}"><a href="/getting-started/model-tuning/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Model tuning</a></li>
-      <li class="pure-menu-item {{ispage getting-started/ensembles/index.html}}pure-menu-selected{{end}}"><a href="/getting-started/ensembles/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Ensembles</a></li>
-      <li class="pure-menu-item {{ispage getting-started/ensembles-2/index.html}}pure-menu-selected{{end}}"><a href="/getting-started/ensembles-2/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Ensembles (2)</a></li>
-      <li class="pure-menu-item {{ispage getting-started/ensembles-3/index.html}}pure-menu-selected{{end}}"><a href="/getting-started/ensembles-3/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Ensembles (3)</a></li>
-      <li class="pure-menu-item {{ispage getting-started/composing-models/index.html}}pure-menu-selected{{end}}"><a href="/getting-started/composing-models/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Composing models</a></li>
-      <li class="pure-menu-item {{ispage getting-started/learning-networks/index.html}}pure-menu-selected{{end}}"><a href="/getting-started/learning-networks/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Learning networks</a></li>
-      <li class="pure-menu-item {{ispage getting-started/learning-networks-2/index.html}}pure-menu-selected{{end}}"><a href="/getting-started/learning-networks-2/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Learning networks (2)</a></li>
-      <li class="pure-menu-item {{ispage getting-started/stacking/index.html}}pure-menu-selected{{end}}"><a href="/getting-started/stacking/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Stacking</a></li>
-    </ul>
-
-    <!-- INTRO TO STATS LEARNING -->
-    <li class="pure-menu-sublist-title"><strong>Intro to Stats Learning</strong></li>
-    <ul class="pure-menu-sublist" id=isl>
-      <li class="pure-menu-item {{ispage isl/lab-2/index.html}}pure-menu-selected{{end}}"><a href="/isl/lab-2/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Lab 2</a></li>
-      <li class="pure-menu-item "><a href="/isl/lab-3/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Lab 3</a></li>
-      <li class="pure-menu-item "><a href="/isl/lab-4/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Lab 4</a></li>
-      <li class="pure-menu-item "><a href="/isl/lab-5/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Lab 5</a></li>
-      <li class="pure-menu-item "><a href="/isl/lab-6b/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Lab 6b</a></li>
-      <li class="pure-menu-item "><a href="/isl/lab-8/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Lab 8</a></li>
-      <li class="pure-menu-item "><a href="/isl/lab-9/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Lab 9</a></li>
-      <li class="pure-menu-item "><a href="/isl/lab-10/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Lab 10</a></li>
-    </ul>
-
-    <!-- END TO END EXAMPLES -->
-    <li class="pure-menu-sublist-title"><strong>End to end examples</strong></li>
-    <ul class="pure-menu-sublist" id=e2e>
-      <li class="pure-menu-item {{ispage end-to-end/telco/index.html}}pure-menu-selected{{end}}"><a href="/end-to-end/telco/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span>Telco Churn</a></li>
-      <li class="pure-menu-item {{ispage end-to-end/AMES/index.html}}pure-menu-selected{{end}}"><a href="/end-to-end/AMES/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> AMES</a></li>
-      <li class="pure-menu-item "><a href="/end-to-end/wine/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Wine</a></li>
-      <li class="pure-menu-item {{ispage end-to-end/crabs-xgb/index.html}}pure-menu-selected{{end}}"><a href="/end-to-end/crabs-xgb/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Crabs (XGB)</a></li>
-      <li class="pure-menu-item "><a href="/end-to-end/horse/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Horse</a></li>
-      <li class="pure-menu-item "><a href="/end-to-end/HouseKingCounty/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> King County Houses</a></li>
-      <li class="pure-menu-item "><a href="/end-to-end/airfoil" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Airfoil </a></li>
-      <li class="pure-menu-item "><a href="/end-to-end/boston-lgbm" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Boston (lgbm) </a></li>
-      <li class="pure-menu-item "><a href="/end-to-end/glm/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Using GLM.jl </a></li>
-      <li class="pure-menu-item "><a href="/end-to-end/powergen/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Power Generation </a></li>
-      <li class="pure-menu-item "><a href="/end-to-end/boston-flux" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Boston (Flux) </a></li>
-      <li class="pure-menu-item "><a href="/end-to-end/breastcancer" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Breast Cancer</a></li>
-    </ul>
-  </ul>
-  <!-- END OF LIST OF MENU ITEMS -->
+          <!-- GETTING STARTED WITH MLJ -->
+          <div class="dropdown">
+            <li class="pure-menu-sublist-title"><strong>Getting started</strong></li>
+          </div>
+          <div class="collapse dropdown-content">
+            <ul class="pure-menu-sublist">
+              <li
+                class="pure-menu-item {{ispage /getting-started/choosing-a-model/index.html}}pure-menu-selected{{end}}">
+                <a href="/getting-started/choosing-a-model/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Choosing a model</a></li>
+              <li class="pure-menu-item {{ispage getting-started/fit-and-predict/index.html}}pure-menu-selected{{end}}">
+                <a href="/getting-started/fit-and-predict/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Fit, predict, transform</a></li>
+              <li class="pure-menu-item {{ispage getting-started/model-tuning/index.html}}pure-menu-selected{{end}}"><a
+                  href="/getting-started/model-tuning/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Model tuning</a></li>
+              <li class="pure-menu-item {{ispage getting-started/ensembles/index.html}}pure-menu-selected{{end}}"><a
+                  href="/getting-started/ensembles/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span>
+                  Ensembles</a></li>
+              <li class="pure-menu-item {{ispage getting-started/ensembles-2/index.html}}pure-menu-selected{{end}}"><a
+                  href="/getting-started/ensembles-2/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Ensembles (2)</a></li>
+              <li class="pure-menu-item {{ispage getting-started/ensembles-3/index.html}}pure-menu-selected{{end}}"><a
+                  href="/getting-started/ensembles-3/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Ensembles (3)</a></li>
+              <li
+                class="pure-menu-item {{ispage getting-started/composing-models/index.html}}pure-menu-selected{{end}}">
+                <a href="/getting-started/composing-models/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Composing models</a></li>
+              <li
+                class="pure-menu-item {{ispage getting-started/learning-networks/index.html}}pure-menu-selected{{end}}">
+                <a href="/getting-started/learning-networks/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Learning networks</a></li>
+              <li
+                class="pure-menu-item {{ispage getting-started/learning-networks-2/index.html}}pure-menu-selected{{end}}">
+                <a href="/getting-started/learning-networks-2/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Learning networks (2)</a></li>
+              <li class="pure-menu-item {{ispage getting-started/stacking/index.html}}pure-menu-selected{{end}}"><a
+                  href="/getting-started/stacking/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span>
+                  Stacking</a></li>
+            </ul>
+          </div>
+          <!-- INTRO TO STATS LEARNING -->
+          <div class="dropdown">
+            <li class="pure-menu-sublist-title"><strong>Intro to Stats Learning</strong></li>
+          </div>
+          <div class="collapse dropdown-content">
+            <ul class="pure-menu-sublist" id=isl>
+              <li class="pure-menu-item {{ispage isl/lab-2/index.html}}pure-menu-selected{{end}}"><a href="/isl/lab-2/"
+                  class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> Lab 2</a></li>
+              <li class="pure-menu-item "><a href="/isl/lab-3/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Lab 3</a></li>
+              <li class="pure-menu-item "><a href="/isl/lab-4/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Lab 4</a></li>
+              <li class="pure-menu-item "><a href="/isl/lab-5/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Lab 5</a></li>
+              <li class="pure-menu-item "><a href="/isl/lab-6b/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Lab 6b</a></li>
+              <li class="pure-menu-item "><a href="/isl/lab-8/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Lab 8</a></li>
+              <li class="pure-menu-item "><a href="/isl/lab-9/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Lab 9</a></li>
+              <li class="pure-menu-item "><a href="/isl/lab-10/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Lab 10</a></li>
+            </ul>
+          </div>
+          <!-- END TO END EXAMPLES -->
+          <div class="dropdown">
+            <li class="pure-menu-sublist-title"><strong>End to end examples</strong></li>
+          </div>
+          <div class="dropdown-content collapse">
+            <ul class="pure-menu-sublist" id=e2e>
+              <li class="pure-menu-item {{ispage end-to-end/telco/index.html}}pure-menu-selected{{end}}"><a
+                  href="/end-to-end/telco/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span>Telco
+                  Churn</a></li>
+              <li class="pure-menu-item {{ispage end-to-end/AMES/index.html}}pure-menu-selected{{end}}"><a
+                  href="/end-to-end/AMES/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span> AMES</a>
+              </li>
+              <li class="pure-menu-item "><a href="/end-to-end/wine/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Wine</a></li>
+              <li class="pure-menu-item {{ispage end-to-end/crabs-xgb/index.html}}pure-menu-selected{{end}}"><a
+                  href="/end-to-end/crabs-xgb/" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span>
+                  Crabs (XGB)</a></li>
+              <li class="pure-menu-item "><a href="/end-to-end/horse/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Horse</a></li>
+              <li class="pure-menu-item "><a href="/end-to-end/HouseKingCounty/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> King County Houses</a></li>
+              <li class="pure-menu-item "><a href="/end-to-end/airfoil" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Airfoil </a></li>
+              <li class="pure-menu-item "><a href="/end-to-end/boston-lgbm" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Boston (lgbm) </a></li>
+              <li class="pure-menu-item "><a href="/end-to-end/glm/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Using GLM.jl </a></li>
+              <li class="pure-menu-item "><a href="/end-to-end/powergen/" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Power Generation </a></li>
+              <li class="pure-menu-item "><a href="/end-to-end/boston-flux" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Boston (Flux) </a></li>
+              <li class="pure-menu-item "><a href="/end-to-end/breastcancer" class="pure-menu-link"><span
+                    style="padding-right:0.5rem;">•</span> Breast Cancer</a></li>
+            </ul>
+          </div>
+        </ul>
+        <!-- END OF LIST OF MENU ITEMS -->
       </div>
     </div>
     <div id="main"> <!-- Closed in foot -->
@@ -101,4 +175,4 @@
       </div>
       {{end}}
 
-<!-- Content appended here -->
+      <!-- Content appended here -->

--- a/_libs/collapse/collapse.js
+++ b/_libs/collapse/collapse.js
@@ -1,0 +1,94 @@
+document.addEventListener("DOMContentLoaded", function () {
+  var filename = window.location.pathname;
+  // Get all elements with class name "dropdown"
+  var dropdowns = document.querySelectorAll(".dropdown");
+
+  // Iterate through each dropdown
+  dropdowns.forEach(function (dropdown, index) {
+    // Find the first heading or li tag inside the dropdown
+    var heading = dropdown.querySelector("h1, h2, h3, h4, h5, h6, li");
+    // make heading have cursor pointer
+    heading.style.cursor = "pointer";
+    // Create a span element with class "triangle" and content " ▼ "
+    var triangleImage = document.createElement("img");
+    triangleImage.className = "triangle";
+    triangleImage.src = dropdown.nextElementSibling.classList.contains(
+      "collapse"
+    )
+      ? "/assets/right-icon.svg"
+      : "/assets/down-icon.svg";
+
+      // check local storage localStorage.setItem("dropdown-" + index, newContent); but get
+     const restoreMemory = function (localName) {
+     if (localStorage.getItem(localName)) {
+      const newContent = localStorage.getItem(localName);
+      triangleImage.src =  (newContent.includes("right-icon")) ? "/assets/right-icon.svg" : "/assets/down-icon.svg";
+      var dropdownContent = dropdown.nextElementSibling;
+        if (newContent.includes("down-icon")) {
+          dropdownContent.style.display = "block";
+        }
+       else {
+         dropdownContent.style.display = "none";
+       }
+     }
+    }
+
+    restoreMemory("dropdown-" + index + filename);
+    // for li tags the memory doesn't depend on the filename (navigation bar always exists)
+    if (heading.tagName === "LI") {
+      restoreMemory("dropdown-" + index + "li");
+    }
+
+    triangleImage.style.cursor = "pointer";
+    triangleImage.style.width = "30px";
+    triangleImage.style.paddingLeft = "0px";
+    triangleImage.style.marginRight = "8px";
+    triangleImage.style.marginBottom = "-7px";
+
+    // Prepend the triangle span to the heading
+    heading.insertBefore(triangleImage, heading.firstChild);
+
+    // Add click event listener to the triangle span
+    const activation = function () {
+      // Toggle between " ▼ " and " ► " upon click
+      var currentContent = triangleImage.src;
+      var newContent = "";
+
+      // Access the parent sibling div. Should follow that it has class dropdown-content
+      var dropdownContent = dropdown.nextElementSibling;
+
+      if (currentContent.includes("down-icon")) {
+        newContent = currentContent.replace("down-icon", "right-icon");
+        // Hide the dropdown-content
+        if (dropdownContent.classList.contains("dropdown-content")) {
+          dropdownContent.style.display = "none";
+        }
+      } else {
+        newContent = currentContent.replace("right-icon", "down-icon");
+        // Show the dropdown-content
+        if (dropdownContent.classList.contains("dropdown-content")) {
+          dropdownContent.style.display = "block";
+        }
+        
+      }
+      triangleImage.src = newContent;
+
+      // store this state using dropdown index
+      localStorage.setItem("dropdown-" + index + filename , newContent);
+      // if the element is li store it in local storage
+      if (heading.tagName === "LI") {
+        localStorage.setItem("dropdown-" + index + "li" , newContent);
+      }
+    }
+
+    // if heading is an li we don't want to be restricted to clicking on the triangle
+    if (heading.tagName === "LI") {      
+    dropdown.addEventListener("click", activation);
+  }
+   // otherwise there is already an attached onclick event
+    else {
+      triangleImage.addEventListener("click", activation);
+    }
+
+  });
+});

--- a/_literate/A-composing-models/tutorial.jl
+++ b/_literate/A-composing-models/tutorial.jl
@@ -5,7 +5,11 @@ macro OUTPUT()
     return isdefined(Main, :Franklin) ? Franklin.OUT_PATH[] : "/tmp/"
 end;
 
+
+# @@dropdown
 # ## Generating dummy data
+# @@
+# @@dropdown-content
 # Let's start by generating some dummy data with both numerical values and categorical values:
 
 using MLJ
@@ -25,7 +29,13 @@ scitype(X.age)
 
 # We will want to coerce that to `Continuous` so that it can be given to a regressor that expects such values.
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Declaring a pipeline
+# @@
+# @@dropdown-content
 
 # A typical workflow for such data is to one-hot-encode the categorical data and then apply some regression model on the data.
 # Let's say that we want to apply the following steps:
@@ -62,3 +72,6 @@ evaluate(
     resampling=Holdout(),
     measure=rms
 ) |> pprint
+
+# ‎
+# @@

--- a/_literate/A-ensembles-2/tutorial.jl
+++ b/_literate/A-ensembles-2/tutorial.jl
@@ -5,7 +5,11 @@ macro OUTPUT()
     return isdefined(Main, :Franklin) ? Franklin.OUT_PATH[] : "/tmp/"
 end;
 
+
+# @@dropdown
 # ## Prelims
+# @@
+# @@dropdown-content
 #
 # This tutorial builds upon the previous ensemble tutorial with a home-made Random Forest regressor on the "boston" dataset.
 #
@@ -36,7 +40,13 @@ e
 
 # Note that multiple measures can be reported simultaneously.
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Random forest
+# @@
+# @@dropdown-content
 #
 # Let's create an ensemble of DTR and fix the number of subfeatures to 3 for now.
 
@@ -70,7 +80,11 @@ savefig(joinpath(@OUTPUT, "A-ensembles-2-curves.svg")) # hide
 
 forest.n = 150;
 
+
+# @@dropdown
 # ### Tuning
+# @@
+# @@dropdown-content
 #
 # As `forest` is a composite model, it has nested hyperparameters:
 
@@ -94,7 +108,13 @@ e = evaluate!(m, resampling=Holdout(fraction_train=0.8),
               measure=[rms, rmslp1])
 e
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Reporting
+# @@
+# @@dropdown-content
 # Again, you could show a 2D heatmap of the hyperparameters
 
 r = report(m)
@@ -125,3 +145,9 @@ ŷ = predict(m, X)
 @show rms(ŷ, y)
 
 PyPlot.close_figs() # hide
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/A-ensembles-3/tutorial.jl
+++ b/_literate/A-ensembles-3/tutorial.jl
@@ -15,7 +15,11 @@ end;
 # Note that MLJ has a built in model wrapper called `EnsembleModel`
 # for creating bagged ensembles with a few lines of code.
 
+
+# @@dropdown
 # ## Definition of composite model type
+# @@
+# @@dropdown-content
 
 using MLJ
 using PyPlot
@@ -51,7 +55,13 @@ end
 
 one_hundred_models = OneHundredModels()
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Application to data
+# @@
+# @@dropdown-content
 
 X, y = @load_boston;
 
@@ -103,3 +113,6 @@ savefig(joinpath(@OUTPUT, "e2.svg")) # hide
 #-
 
 PyPlot.close_figs() # hide
+
+# ‎
+# @@

--- a/_literate/A-ensembles/tutorial.jl
+++ b/_literate/A-ensembles/tutorial.jl
@@ -5,7 +5,11 @@ macro OUTPUT()
     return isdefined(Main, :Franklin) ? Franklin.OUT_PATH[] : "/tmp/"
 end;
 
+
+# @@dropdown
 # ## Preliminary steps
+# @@
+# @@dropdown-content
 #
 # Let's start by loading the relevant packages and generating some dummy data.
 
@@ -42,7 +46,13 @@ rms(ŷ, y[test])
 evaluate!(knn, resampling=Holdout(fraction_train=0.7, rng=StableRNG(666)),
           measure=rms)
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Homogenous ensembles
+# @@
+# @@dropdown-content
 #
 # MLJ offers basic support for ensembling such as [_bagging_](https://en.wikipedia.org/wiki/Bootstrap_aggregating).
 # Defining such an ensemble of simple "atomic" models is done via the `EnsembleModel` constructor:
@@ -51,7 +61,11 @@ ensemble_model = EnsembleModel(model=knn_model, n=20);
 
 # where the `n=20` indicates how many models are present in the ensemble.
 #
+
+# @@dropdown
 # ### Training and testing an ensemble
+# @@
+# @@dropdown-content
 #
 # Now that we've instantiated an ensemble, it can be trained and tested the same as any other model:
 
@@ -66,7 +80,13 @@ estimates
 
 # Note that multiple measurements can be specified jointly. Here only on measurement is (implicitly) specified but we still have to select the corresponding results (whence the `[1]` for both  the `measurement` and `per_fold`).
 #
+
+# ‎
+# @@
+# @@dropdown
 # ### Systematic tuning
+# @@
+# @@dropdown-content
 #
 # Let's simultaneously tune the ensemble's `bagging_fraction` and the K-Nearest neighbour hyperparameter `K`. Since one of our models is  a field of the  other, we have nested hyperparameters:
 
@@ -92,7 +112,13 @@ fit!(tuned_ensemble, rows=train);
 
 # Note the `rng=42` seeds the random number generator for reproducibility of this example.
 #
+
+# ‎
+# @@
+# @@dropdown
 # ### Reporting results
+# @@
+# @@dropdown-content
 #
 # The best model can be accessed like so:
 
@@ -131,3 +157,9 @@ ŷ = predict(tuned_ensemble, rows=test)
 
 
 PyPlot.close_figs() # hide
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/A-fit-predict/tutorial.jl
+++ b/_literate/A-fit-predict/tutorial.jl
@@ -6,9 +6,17 @@ Pkg.update()
 # [RDatasets.jl]: https://github.com/JuliaStats/RDatasets.jl
 # [DecisionTree.jl]: https://github.com/bensadeghi/DecisionTree.jl
 #
+
+# @@dropdown
 # ## Preliminary steps
+# @@
+# @@dropdown-content
 #
+
+# @@dropdown
 # ### Data
+# @@
+# @@dropdown-content
 #
 # As in "[choosing a model](/getting-started/choosing-a-model/)", let's load the Iris dataset and unpack it:
 
@@ -25,7 +33,13 @@ X, y = @load_iris;
 DecisionTreeClassifier = @load DecisionTreeClassifier pkg=DecisionTree
 tree_model = DecisionTreeClassifier()
 
+
+# ‎
+# @@
+# @@dropdown
 # ### MLJ Machine
+# @@
+# @@dropdown-content
 #
 # In MLJ, remember that a *model* is an object that only serves as a container for the hyperparameters of the model.
 # A *machine* is an object wrapping both a model and data and can contain information on the *trained* model; it does *not* fit the model by itself.
@@ -36,11 +50,24 @@ tree = machine(tree_model, X, y)
 # A machine is used both for supervised and unsupervised model.
 # In this tutorial we give an example for the supervised model first and then go on with the unsupervised case.
 #
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Training and testing a supervised model
+# @@
+# @@dropdown-content
 #
 # Now that you've declared the model you'd like to consider and the data, we are left with the standard training and testing step for a supervised learning algorithm.
 #
+
+# @@dropdown
 # ### Splitting the data
+# @@
+# @@dropdown-content
 #
 # To split the data into a *training* and *testing* set, you can use the function `partition` to obtain indices for data points that should be considered either as training or testing data:
 
@@ -48,7 +75,13 @@ rng = StableRNG(566)
 train, test = partition(eachindex(y), 0.7, shuffle=true, rng=rng)
 test[1:3]
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Fitting and testing the machine
+# @@
+# @@dropdown-content
 #
 # To fit the machine, you can use the function `fit!` specifying the rows to be used for the training:
 
@@ -78,7 +111,16 @@ ȳ = predict_mode(tree, rows=test)
 mce = cross_entropy(ŷ, y[test]) |> mean
 round(mce, digits=4)
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Unsupervised models
+# @@
+# @@dropdown-content
 #
 # Unsupervised models define a `transform` method,
 # and may optionally implement an `inverse_transform` method.
@@ -100,3 +142,6 @@ w = transform(stand, v)
 
 vv = inverse_transform(stand, w)
 sum(abs.(vv .- v))
+
+# ‎
+# @@

--- a/_literate/A-learning-networks-2/tutorial.jl
+++ b/_literate/A-learning-networks-2/tutorial.jl
@@ -3,7 +3,11 @@ Pkg.activate("_literate/A-learning-networks-2/Project.toml")
 Pkg.update()
 
 
+
+# @@dropdown
 # ## Preliminary steps
+# @@
+# @@dropdown-content
 #
 # Let's start as with the previous tutorial:
 
@@ -30,7 +34,13 @@ test, train = partition(eachindex(y), 0.8);
 #
 # Generating a model from a network allows subsequent composition of that network with other tasks and tuning of that network.
 #
+
+# ‎
+# @@
+# @@dropdown
 # ## Using the `@from_network` macro
+# @@
+# @@dropdown-content
 #
 # Let's define a simple network
 #
@@ -91,7 +101,13 @@ res = evaluate!(cm, resampling=Holdout(fraction_train=0.8, rng=51),
                 measure=rms)
 round(res.measurement[1], sigdigits=3)
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Defining a model from scratch
+# @@
+# @@dropdown-content
 #
 # An alternative to the `@from_network`, is to fully define a new model with its `fit` method:
 
@@ -120,3 +136,6 @@ res = evaluate!(cm, resampling=Holdout(fraction_train=0.8), measure=rms)
 round(res.measurement[1], sigdigits=3)
 
 # Either way you now have a constructor to a  model which can be used as a stand-alone object, tuned and composed as you would with any basic model.
+
+# ‎
+# @@

--- a/_literate/A-learning-networks/tutorial.jl
+++ b/_literate/A-learning-networks/tutorial.jl
@@ -2,7 +2,11 @@ using Pkg # hideall
 Pkg.activate("_literate/A-learning-networks/Project.toml")
 Pkg.update();
 
+
+# @@dropdown
 # ## Preliminary steps
+# @@
+# @@dropdown-content
 #
 # Let's generate a `DataFrame` with some dummy regression data, let's also load the good old ridge regressor.
 
@@ -25,7 +29,13 @@ first(X, 3) |> pretty
 
 test, train = partition(eachindex(y), 0.8);
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Defining a learning network
+# @@
+# @@dropdown-content
 #
 # In MLJ, a *learning network* is a directed acyclic graph (DAG) whose *nodes* apply trained or untrained operations such as a `predict` or `transform` (trained) or `+`, `vcat` etc. (untrained).
 # Learning networks can be seen as pipelines on steroids.
@@ -38,7 +48,11 @@ test, train = partition(eachindex(y), 0.8);
 #
 # **Note**: actually  this DAG is simple enough that it could also have been done with a pipeline.
 #
+
+# @@dropdown
 # ### Sources and nodes
+# @@
+# @@dropdown-content
 #
 # In MLJ a learning network starts at **source** nodes and flows through nodes (`X` and `y`) defining operations/transformations (`W`, `z`, `ẑ`, `ŷ`).
 # To define the source nodes, use the `source` function, you should specify whether it's a target:
@@ -82,7 +96,13 @@ fit!(ŷ, rows=train);
 
 rms(y[test], ŷ(rows=test))
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Modifying hyperparameters
+# @@
+# @@dropdown-content
 #
 # Hyperparameters can be accessed using the dot syntax as usual.
 # Let's modify the regularisation parameter of the ridge regression:
@@ -93,3 +113,9 @@ ridge_model.lambda = 5.0;
 
 fit!(ŷ, rows=train)
 rms(y[test], ŷ(rows=test))
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/A-model-choice/tutorial.jl
+++ b/_literate/A-model-choice/tutorial.jl
@@ -9,9 +9,17 @@ Pkg.update()
 # [NearestNeighbors.jl]: https://github.com/KristofferC/NearestNeighbors.jl
 # [GLM.jl]: https://github.com/JuliaStats/GLM.jl
 # [ScikitLearn.jl]: https://github.com/cstjean/ScikitLearn.jl
+
+# @@dropdown
 # ## Data and its interpretation
+# @@
+# @@dropdown-content
 #
+
+# @@dropdown
 # ### Machine type and scientific type
+# @@
+# @@dropdown-content
 
 using RDatasets
 using MLJ
@@ -30,7 +38,13 @@ first(iris, 3) |> pretty
 iris2 = coerce(iris, :PetalWidth => OrderedFactor)
 first(iris2[:, [:PetalLength, :PetalWidth]], 1) |> pretty
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Unpacking data
+# @@
+# @@dropdown-content
 #
 # The function `unpack` helps specify the target and the input for a regression or classification task
 
@@ -52,9 +66,22 @@ first(X, 1) |> pretty
 
 X, y = @load_iris;
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Choosing a model
+# @@
+# @@dropdown-content
 #
+
+# @@dropdown
 # ### Model search
+# @@
+# @@dropdown-content
 #
 # In MLJ, a _model_ is a struct storing the _hyperparameters_ of the learning algorithm indicated by the struct name (and only that).
 #
@@ -67,7 +94,13 @@ for m in models(matching(X, y))
     end
 end
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Loading a model
+# @@
+# @@dropdown-content
 #
 # Most models are implemented outside of the MLJ ecosystem; you therefore have to _load models_ using the `@load` command.
 #
@@ -80,3 +113,9 @@ knc = @load KNeighborsClassifier
 # In some cases, there may be several packages offering the same model, for instance `LinearRegressor` is offered by both `[GLM.jl]` and `[ScikitLearn.jl]` so you will need to specify the package you would like to use by adding `pkg="ThePackage"` in the load command:
 
 linreg = @load LinearRegressor pkg=GLM
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/A-model-tuning/tutorial.jl
+++ b/_literate/A-model-tuning/tutorial.jl
@@ -9,7 +9,11 @@ end
 # [RDatasets.jl]: https://github.com/JuliaStats/RDatasets.jl
 # [NearestNeighbors.jl]: https://github.com/KristofferC/NearestNeighbors.jl
 #
+
+# @@dropdown
 # ## Tuning a single hyperparameter
+# @@
+# @@dropdown-content
 #
 # In MLJ, tuning is implemented as a model wrapper.
 # After wrapping a model in a _tuning strategy_ (e.g. cross-validation) and binding the wrapped model to data in a _machine_, fitting the machine initiates a search for optimal model hyperparameters.
@@ -23,7 +27,11 @@ MLJ.color_off() # hide
 X, y = @load_iris
 DecisionTreeClassifier = @load DecisionTreeClassifier pkg=DecisionTree
 
+
+# @@dropdown
 # ### Specifying a range of value
+# @@
+# @@dropdown-content
 #
 # To specify a range of value, you can use the `range` function:
 
@@ -46,7 +54,13 @@ tm = TunedModel(model=dtc, ranges=[r, ], measure=cross_entropy)
 
 # For more options do `?TunedModel`.
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Fitting and inspecting a tuned model
+# @@
+# @@dropdown-content
 #
 # To fit a tuned model, you can use the usual syntax:
 
@@ -89,7 +103,16 @@ savefig(joinpath(@OUTPUT, "A-model-tuning-hpt.svg")) # hide
 
 # \figalt{hyperparameter heatmap}{A-model-tuning-hpt}
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Tuning nested hyperparameters
+# @@
+# @@dropdown-content
 
 # Let's generate simple dummy regression data
 
@@ -140,3 +163,6 @@ savefig(joinpath(@OUTPUT, "A-model-tuning-hm.svg")) # hide
 
 # \figalt{Hyperparameter heatmap}{A-model-tuning-hm.svg}
 PyPlot.close_figs() # hide
+
+# ‎
+# @@

--- a/_literate/A-stacking/tutorial.jl
+++ b/_literate/A-stacking/tutorial.jl
@@ -23,7 +23,11 @@ end;
 # `MyTwoStack`.
 
 
+
+# @@dropdown
 # ## Basic stacking using out-of-sample base learner predictions
+# @@
+# @@dropdown-content
 
 # A rather general stacking protocol was first described in a [1992
 # paper](https://www.sciencedirect.com/science/article/abs/pii/S0893608005800231)
@@ -78,7 +82,11 @@ forest = (@load RandomForestRegressor pkg=DecisionTree)()
 svm = (@load SVMRegressor)()
 
 
+
+# @@dropdown
 # ### Warm-up exercise: Define a model type to average predictions
+# @@
+# @@dropdown-content
 
 # Let's define a composite model type `MyAverageTwo` that
 # averages the predictions of two deterministic regressors. Here's the learning network:
@@ -145,8 +153,21 @@ print_performance(linear, X, y)
 print_performance(knn, X, y)
 print_performance(average_two, X, y)
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Stacking proper
+# @@
+# @@dropdown-content
+
+# @@dropdown
 # ### Helper functions:
+# @@
+# @@dropdown-content
 
 # To generate folds for generating out-of-sample predictions, we define
 
@@ -167,7 +188,13 @@ f = folds(1:10, 3)
 corestrict(string.(1:10), f, 2)
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Choose some test data (optional) and some component models (defaults for the composite model):
+# @@
+# @@dropdown-content
 
 figure(figsize=(8,6))
 steps(x) = x < -3/2 ? -1 : (x < 3/2 ? 0 : 1)
@@ -196,7 +223,13 @@ model2 = knn
 judge = linear
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Define the training nodes
+# @@
+# @@dropdown-content
 
 # Let's instantiate some input and target source nodes for the
 # learning network, wrapping the play data defined above in source
@@ -309,7 +342,13 @@ m1 = machine(model1, X, y)
 m2 = machine(model2, X, y)
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Define nodes still needed for prediction
+# @@
+# @@dropdown-content
 
 # To obtain the final prediction, `yhat`, we get the base learner
 # predictions, based on training with all data, and feed them to the
@@ -341,7 +380,16 @@ estack = rms(yhat(), y())
 @show e1 e2 emean estack;
 
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Export the learning network as a new model type
+# @@
+# @@dropdown-content
 
 # The learning network (less the data wrapped in the source nodes)
 # amounts to a specification of a new composite model type for
@@ -362,7 +410,13 @@ my_two_model_stack = MyTwoModelStack()
 # And this completes the definition of our re-usable stacking model type.
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Applying `MyTwoModelStack` to some data
+# @@
+# @@dropdown-content
 
 # Without undertaking any hyperparameter optimization, we evaluate the
 # performance of a tree boosting algorithm and a support vector
@@ -427,3 +481,6 @@ best_stack.regressor2.C
 print_performance(best_stack, X, y)
 
 PyPlot.close_figs() # hide
+
+# ‎
+# @@

--- a/_literate/D0-categorical/tutorial.jl
+++ b/_literate/D0-categorical/tutorial.jl
@@ -4,7 +4,11 @@ Pkg.update()
 
 # This tutorial follows loosely [the docs](https://juliadata.github.io/CategoricalArrays.jl/latest/using.html).
 #
+
+# @@dropdown
 # ## Defining a categorical vector
+# @@
+# @@dropdown-content
 
 using CategoricalArrays
 
@@ -17,9 +21,19 @@ levels(v)
 
 # which, by  default, returns the labels in lexicographic order.
 #
+
+# ‎
+# @@
+# @@dropdown
 # ## Working with categoricals
+# @@
+# @@dropdown-content
 #
+
+# @@dropdown
 # ### Ordered categoricals
+# @@
+# @@dropdown-content
 #
 # You can specify that categories are *ordered* by specifying `ordered=true`, the order then follows that of the levels. If you wish to change that order, you  need to  use the `levels!` function.
 # Let's see two examples.
@@ -50,7 +64,13 @@ levels!(v, ["low", "med", "high"])
 
 v[1] < v[2]
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Missing values
+# @@
+# @@dropdown-content
 #
 # You can also have a categorical vector with missing values:
 
@@ -59,3 +79,9 @@ v = categorical(["AA", "BB", missing, "AA", "BB", "CC"]);
 # that doesn't change the levels:
 
 levels(v)
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/D0-dataframe/tutorial.jl
+++ b/_literate/D0-dataframe/tutorial.jl
@@ -5,7 +5,11 @@ Pkg.update()
 # This tutorial is loosely adapted from [this pandas tutorial](https://pandas.pydata.org/pandas-docs/stable/getting_started/10min.html) as well as the [DataFrames.jl documentation](http://juliadata.github.io/DataFrames.jl/latest/man/getting_started/).
 # It is by no means meant to be a complete introduction, rather, it focuses on some key functionalities that are particularly useful in a classical machine learning context.
 #
+
+# @@dropdown
 # ## Basics
+# @@
+# @@dropdown-content
 #
 # To start with, we will use the `Boston` dataset which is very simple.
 
@@ -18,7 +22,11 @@ boston = dataset("MASS", "Boston");
 
 typeof(boston)
 
+
+# @@dropdown
 # ### Accessing data
+# @@
+# @@dropdown-content
 #
 # Intuitively a DataFrame is just a wrapper around a number of columns, each of which is a `Vector` of some type with a name"
 
@@ -59,7 +67,13 @@ first(b2, 2)
 select!(b1, Not(:Crim))
 first(b1, 2)
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Describing the data
+# @@
+# @@dropdown-content
 #
 # `StatsBase` offers a convenient `describe` function which you can use on a DataFrame to get an overview of the data:
 
@@ -85,14 +99,26 @@ first(d, 3)
 using Statistics
 
 #
+
+# ‎
+# @@
+# @@dropdown
 # ### Converting the data
+# @@
+# @@dropdown-content
 #
 # If you want to get the content of the dataframe as one big matrix, use `convert`:
 
 mat = Matrix(boston)
 mat[1:3, 1:3]
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Adding columns
+# @@
+# @@dropdown-content
 #
 # Adding a column to a dataframe is very easy:
 
@@ -100,7 +126,13 @@ boston.Crim_x_Zn = boston.Crim .* boston.Zn;
 
 # that's it! Remember also that you can drop columns or make subselections with `select` and `select!`.
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Missing values
+# @@
+# @@dropdown-content
 #
 # Let's load a dataset with missing values
 
@@ -117,14 +149,27 @@ std(mao.Age)
 std(skipmissing(mao.Age))
 
 #
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Split-Apply-Combine
+# @@
+# @@dropdown-content
 #
 # This is a shorter version of the [DataFrames.jl tutorial](http://juliadata.github.io/DataFrames.jl/latest/man/split_apply_combine/).
 
 iris = dataset("datasets", "iris")
 first(iris, 3)
 
+
+# @@dropdown
 # ### `groupby`
+# @@
+# @@dropdown-content
 #
 # The `groupby` function allows to form "sub-dataframes" corresponding to groups of rows.
 # This can be very convenient to run specific analyses for specific groups without copying the data.
@@ -148,7 +193,13 @@ describe(subdf_setosa, :min, :mean, :max)
 #
 # See `?groupby` for more information.
 #
+
+# ‎
+# @@
+# @@dropdown
 # ### `combine`
+# @@
+# @@dropdown-content
 #
 # The `combine` function allows to derive a new dataframe out of transformations of an existing one.
 # Here's an example taken from the official doc (see `?combine`):
@@ -169,7 +220,13 @@ combine(df, :a => maximum, :b => foo)
 bar(v) = v[end-1:end]
 combine(df, :a => foo, :b => bar)
 
+
+# ‎
+# @@
+# @@dropdown
 # ### `combine` with `groupby`
+# @@
+# @@dropdown-content
 #
 # Combining `groupby` with `combine` is very useful.
 # For instance you might want to compute statistics across groups for different variables:
@@ -200,3 +257,9 @@ names(iris, Not(:Species))
 
 #
 # and note the use of `.` in `.=>` to indicate that we broadcast the function over each column.
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/D0-loading/tutorial.jl
+++ b/_literate/D0-loading/tutorial.jl
@@ -8,7 +8,11 @@ Pkg.update()
 # 1. loading a standard dataset via `RDatasets.jl`,
 # 1. loading a local file with `CSV.jl`,
 #
+
+# @@dropdown
 # ## Using RDatasets
+# @@
+# @@dropdown-content
 #
 # The package [RDatasets.jl](https://github.com/JuliaStats/RDatasets.jl) provides access to most of the many datasets listed on [this page](http://vincentarelbundock.github.io/Rdatasets/datasets.html).
 # These are well known, standard datasets that can be used to get started with data processing and classical machine learning such as for instance `iris`, `crabs`, `Boston`, etc.
@@ -29,12 +33,22 @@ typeof(boston)
 
 # For a short introduction to DataFrame objects, see [this tutorial](/data/dataframe).
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Using CSV
+# @@
+# @@dropdown-content
 #
 # The package [CSV.jl](https://github.com/JuliaData/CSV.jl) offers a powerful way to read arbitrary CSV files efficiently.
 # In particular the `CSV.read` function allows to read a file and return a DataFrame.
 #
+
+# @@dropdown
 # ### Basic usage
+# @@
+# @@dropdown-content
 #
 # Let's say you have a file `foo.csv` at some path `fpath=joinpath("data", "foo.csv")` with the content
 #
@@ -75,7 +89,13 @@ typeof(data)
 #
 # For more details see `?CSV.File`.
 #
+
+# ‎
+# @@
+# @@dropdown
 # ### Example 1
+# @@
+# @@dropdown-content
 #
 # Let's consider [this dataset](https://archive.ics.uci.edu/ml/machine-learning-databases/00504/), the content of which we saved in a file at path `fpath`.
 
@@ -114,7 +134,13 @@ header = ["CIC0", "SM1_Dz", "GATS1i",
 data = CSV.read(fpath, DataFrames.DataFrame, header=header)
 first(data, 3)
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Example 2
+# @@
+# @@dropdown-content
 #
 # Let's consider [this dataset](https://archive.ics.uci.edu/ml/machine-learning-databases/00423/), the content of which we saved at `fpath`.
 
@@ -147,3 +173,9 @@ write(fpath, c);
 
 data = CSV.read(fpath, DataFrames.DataFrame, header=false, missingstring="?")
 first(data[:, 1:5], 3)
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/D0-processing/tutorial.jl
+++ b/_literate/D0-processing/tutorial.jl
@@ -5,7 +5,11 @@ macro OUTPUT()
     return isdefined(Main, :Franklin) ? Franklin.OUT_PATH[] : "/tmp/"
 end;
 
+
+# @@dropdown
 # ## More data processing
+# @@
+# @@dropdown-content
 #
 # This tutorial uses the World Resources Institute Global Power Plants Dataset to explore data pre-processing in Julia.
 # The dataset is created from multiple sources and is under continuous update, which means that there are lots of missing data, non-standard characters, etc
@@ -55,7 +59,7 @@ describe(data)
 # The describe() function shows that there are several features with missing values.
 # *Note:* the `describe()` function is from the `DataFrames` package (and won't work with other, non DataFrames, tables) whereas the `schema()` is from the MLJ package.
 
-# ---
+
 # Let's play around with capacity data, for which there are no missing values. We create a sub-dataframe and aggregate over certain dimensions (country and primary_fuel)
 capacity = select(data, [:country, :primary_fuel, :capacity_mw]);
 first(capacity, 5)
@@ -92,7 +96,7 @@ savefig(joinpath(@OUTPUT, "D0-processing-g1.svg")) # hide
 
 # \figalt{processing1}{D0-processing-g1.svg}
 
-# ---
+
 # Now that we have the total capacity by country and technology type, let's use it to calculate the share of each technology in total capacity.
 # To that end we first create a dataframe containing the country-level total capacity, using the same steps as above.
 cap_sum_ctry_gd = groupby(capacity, [:country]);
@@ -107,7 +111,7 @@ cap_share.capacity_mw_share = cap_share.capacity_mw_sum ./ cap_share.capacity_mw
 
 # Let's visualise our dataframe again, which now includes the `capacity_mw_share` column.
 
-# ---
+
 # Now let's analyse features which exhibit some missing values.
 # Suppose we want to calculate the age of each plant (rounded to full years). We face two issues.
 # First, the commissioning_year is not reported for all plants.
@@ -187,3 +191,6 @@ ax2.set_title("Gas")
 savefig(joinpath(@OUTPUT, "D0-processing-g3.svg")) # hide
 
 # \figalt{processing3}{D0-processing-g3.svg}
+
+# ‎
+# @@

--- a/_literate/D0-scitype/tutorial.jl
+++ b/_literate/D0-scitype/tutorial.jl
@@ -2,9 +2,17 @@ using Pkg  # hideall
 Pkg.activate("_literate/D0-scitype/Project.toml")
 Pkg.update()
 
+
+# @@dropdown
 # ## Machine type vs Scientific Type
+# @@
+# @@dropdown-content
 #
+
+# @@dropdown
 # ### Why make a distinction?
+# @@
+# @@dropdown-content
 #
 # When analysing data, it is important to distinguish between
 #
@@ -23,7 +31,13 @@ Pkg.update()
 # * A vector of `String` e.g. `["John", "Maria", ...]` which should not interpreted as informative data,
 # * A vector of floating points `[1.5,  1.5, -2.3, -2.3]` which should be interpreted as categorical data (e.g. the few possible values of some setting), etc.
 #
+
+# ‎
+# @@
+# @@dropdown
 # ### The Scientific Types
+# @@
+# @@dropdown-content
 #
 # The package [ScientificTypes.jl](https://github.com/JuliaAI/ScientificTypes.jl) defines a barebone type hierarchy which can be used to indicate how a particular feature should be interpreted; in particular:
 #
@@ -46,7 +60,13 @@ Pkg.update()
 # This is what we will use throughout; you never need to use ScientificTypes.jl
 # unless you intend to implement your own scientific type convention.
 #
+
+# ‎
+# @@
+# @@dropdown
 # ### Inspecting the scitype
+# @@
+# @@dropdown-content
 #
 # The `schema` function
 
@@ -71,7 +91,13 @@ unique(boston.Chas)
 # default  interpretation of `Count`, it would be more appropriate to interpret
 # it as an `OrderedFactor`.
 #
+
+# ‎
+# @@
+# @@dropdown
 # ### Changing the scitype
+# @@
+# @@dropdown-content
 #
 # In order to re-specify the scitype(s) of  feature(s) in a dataset, you can
 # use the `coerce` function and  specify pairs of variable name and  scientific
@@ -92,7 +118,13 @@ elscitype(boston2.Chas)
 
 boston3 = coerce(boston, :Chas => OrderedFactor, :Rad => OrderedFactor);
 
+
+# ‎
+# @@
+# @@dropdown
 # ### String and Unknown
+# @@
+# @@dropdown-content
 #
 # If a feature in  your dataset has String elements, then the  default scitype
 # is `Textual`; you can either choose to  drop  such columns or to coerce them
@@ -106,9 +138,22 @@ elscitype(feature)
 feature2 = coerce(feature, Multiclass)
 elscitype(feature2)
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Tips and tricks
+# @@
+# @@dropdown-content
 #
+
+# @@dropdown
 # ### Type to Type coercion
+# @@
+# @@dropdown-content
 #
 # In  some cases you will want to reinterpret all features currently
 # interpreted as some scitype `S1` into some other scitype `S2`.
@@ -125,7 +170,13 @@ data2 = coerce(data, Count => Continuous)
 schema(data2)
 
 #
+
+# ‎
+# @@
+# @@dropdown
 # ### Autotype
+# @@
+# @@dropdown-content
 #
 # A last useful tool is `autotype` which allows you to specify *rules* to
 # define the interpretation of features automatically.
@@ -145,3 +196,9 @@ boston3 = coerce(boston, autotype(boston, :few_to_finite))
 schema(boston3)
 
 # You can also specify multiple rules, see [the docs](https://juliaai.github.io/ScientificTypes.jl/dev/#Automatic-type-conversion) for more information.
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/DRAFT_EX-cardfraud/tutorial.jl
+++ b/_literate/DRAFT_EX-cardfraud/tutorial.jl
@@ -34,7 +34,11 @@ using Flux.Data
 
 # ***
 
+
+# @@dropdown
 # ## *Data Preparation*
+# @@
+# @@dropdown-content
 
 # Divide the sample into two equal sub-samples. Keep the proportion of frauds the same in each sub-sample (246 frauds in each).
 # Use one sub-sample to estimate (train) your models and the second one to evaluate the out-of-sample performance of each model.
@@ -96,7 +100,11 @@ Xtest_std = MLJModels.transform(std_m_fit, Xtest)
 # 2. support vector machines
 # 3. neural network.
 
+
+# @@dropdown
 # ### Logit
+# @@
+# @@dropdown-content
 
 # **Initial logit classification with lambda = 1.0**
 @load LogisticClassifier pkg=MLJLinearModels
@@ -125,7 +133,13 @@ yhat_logit = categorical(mode.(yhat_logit_p))
 
 # ***
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Tuned logit
+# @@
+# @@dropdown-content
 
 # Still LogisticClassifier but implementing hyperparameter tuning.
 
@@ -149,7 +163,13 @@ yhat_logit_tuned = categorical(mode.(yhat_logit_tuned_p))
 # Let's take a look at the misclassification_rate. It is, surprisingly, slightly higher than the one calculated for the non tuned model.
 @show misclassification_rate(yhat_logit_tuned, ytest_cat)
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Support Vector Machine
+# @@
+# @@dropdown-content
 
 # ***
 
@@ -204,7 +224,13 @@ yhat_svm_tuned = MLJBase.predict(self_tuning_svm, Xtest_std)
 
 #CSV.write("yhat_svm_tuned.csv", yhat_svm_tuned)
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Neural Network
+# @@
+# @@dropdown-content
 
 #oversample fraudulent cases (since data so imbalanced)
 X_train_oversampled = vcat(X_train,repeat(data_fraud[1:Int(nrow(data_fraud)/2),1:29], 100))
@@ -290,3 +316,9 @@ plot(prcurve(yhat_nn_p, y_test_int))
 
 
 #END
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/EX-AMES/tutorial.jl
+++ b/_literate/EX-AMES/tutorial.jl
@@ -2,7 +2,11 @@ using Pkg # hideall
 Pkg.activate("_literate/EX-AMES/Project.toml")
 Pkg.update()
 
+
+# @@dropdown
 # ## Baby steps
+# @@
+# @@dropdown-content
 #
 # Let's load a reduced version of the well-known Ames House Price data set (containing six of the more important categorical features and six of the more important numerical features).
 # As "iris" the dataset is so common that you can load it directly with `@load_ames` and the reduced version via `@load_reduced_ames`
@@ -25,7 +29,13 @@ scitype(y)
 
 # so this is a standard regression problem with a mix of categorical and continuous input.
 #
+
+# ‎
+# @@
+# @@dropdown
 # ## Dummy model
+# @@
+# @@dropdown-content
 #
 # Remember that a model is just a container for hyperparameters; let's take a particularly simple one: the constant regression.
 
@@ -54,7 +64,13 @@ ŷ[1:3]
 rmsl(ŷ, y[test])
 
 #
+
+# ‎
+# @@
+# @@dropdown
 # ## KNN-Ridge blend
+# @@
+# @@dropdown-content
 #
 # Let's try something a bit fancier than a constant regressor.
 #
@@ -69,7 +85,11 @@ rmsl(ŷ, y[test])
 RidgeRegressor = @load RidgeRegressor pkg="MultivariateStats"
 KNNRegressor = @load KNNRegressor
 
+
+# @@dropdown
 # ### Using the expanded syntax
+# @@
+# @@dropdown-content
 #
 # Let's start by defining the source nodes:
 
@@ -106,7 +126,13 @@ ypreds = ŷ(rows=test)
 rmsl(y[test], ypreds)
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Tuning the model
+# @@
+# @@dropdown-content
 #
 # So far the hyperparameters were explicitly given but it makes more sense to learn them.
 # For this, we define a model around the learning network which can then be trained and tuned as any model:
@@ -192,3 +218,9 @@ krb_best = fitted_params(mtm).best_model
 
 preds = predict(mtm, rows=test)
 rmsl(y[test], preds)
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/EX-GLM/tutorial.jl
+++ b/_literate/EX-GLM/tutorial.jl
@@ -18,7 +18,11 @@ using UrlDownload
 LinearRegressor = @load LinearRegressor pkg=GLM
 LinearBinaryClassifier = @load LinearBinaryClassifier pkg=GLM
 
+
+# @@dropdown
 # ## Reading the data
+# @@
+# @@dropdown-content
 #
 # The CollegeDistance dataset was stored in a CSV file.  Here, we read the input file.
 
@@ -37,7 +41,13 @@ first(dfX, 3)
 
 first(dfY1, 3)
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Defining the Linear Model
+# @@
+# @@dropdown-content
 #
 # Let see how many MLJ models handle our kind of target which is the y variable.
 
@@ -71,7 +81,13 @@ LinearModel = machine(LinearRegressorPipe, X, yv)
 fit!(LinearModel)
 fp = fitted_params(LinearModel)
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Reading the Output of Fitting the Linear Model
+# @@
+# @@dropdown-content
 #
 # We can quickly read the results of our models in MLJ.  Remember to compute the accuracy of the linear model.
 
@@ -92,7 +108,13 @@ println("\n Standard Error per Coefficient \n", r.linear_regressor.stderror[2:en
 
 round(rms(yhatResponse, y[:,1]), sigdigits=4)
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Defining the Logistic Model
+# @@
+# @@dropdown-content
 
 X = copy(dfX)
 y = copy(dfYbinary)
@@ -111,7 +133,13 @@ LogisticModel = machine(LinearBinaryClassifierPipe, X, yc)
 fit!(LogisticModel)
 fp = fitted_params(LogisticModel)
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Reading the Output from the Prediction of the Logistic Model
+# @@
+# @@dropdown-content
 #
 # The output of the MLJ model basically contain the same information as the R version of the model.
 
@@ -132,3 +160,6 @@ yMode = [mode(ŷ[i]) for i in 1:length(ŷ)]
 y = coerce(y[:,1], OrderedFactor)
 yMode = coerce(yMode, OrderedFactor)
 confusion_matrix(yMode, y)
+
+# ‎
+# @@

--- a/_literate/EX-airfoil/tutorial.jl
+++ b/_literate/EX-airfoil/tutorial.jl
@@ -7,9 +7,17 @@ end;
 
 # **Main author**: [Ashrya Agrawal](https://github.com/ashryaagr).
 #
+
+# @@dropdown
 # ## Getting started
+# @@
+# @@dropdown-content
 # Here we use the [UCI "Airfoil Self-Noise" dataset](http://archive.ics.uci.edu/ml/datasets/Airfoil+Self-Noise)
+
+# @@dropdown
 # ### Loading and  preparing the data
+# @@
+# @@dropdown-content
 
 using MLJ
 using PrettyPrinting
@@ -62,7 +70,16 @@ for model in models(matching(X, y))
        print("Model Name: " , model.name , " , Package: " , model.package_name , "\n")
 end
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## DecisionTreeRegressor
+# @@
+# @@dropdown-content
 #
 # We will first try out DecisionTreeRegressor:
 
@@ -77,7 +94,13 @@ pred_dcrm = predict(dcrm, rows=test);
 
 rms(pred_dcrm, y[test])
 
+
+# ‎
+# @@
+# @@dropdown
 # ## RandomForestRegressor
+# @@
+# @@dropdown-content
 #
 # Now let's try out RandomForestRegressor:
 
@@ -99,7 +122,13 @@ rms(pred_rfr, y[test])
 #
 # Can we do even better? Yeah, we can!! We can make use of Model Tuning.
 #
+
+# ‎
+# @@
+# @@dropdown
 # ## Tuning
+# @@
+# @@dropdown-content
 #
 # In case you are new to model tuning using MLJ, refer [lab5](https://alan-turing-institute.github.io/DataScienceTutorials.jl/isl/lab-5/) and [model-tuning](https://alan-turing-institute.github.io/DataScienceTutorials.jl/getting-started/model-tuning/)
 #
@@ -155,3 +184,6 @@ plt.savefig(joinpath(@OUTPUT, "airfoil_heatmap.svg")) # hide
 # \figalt{Hyperparameter heatmap}{airfoil_heatmap.svg}
 
 PyPlot.close_figs() # hide
+
+# ‎
+# @@

--- a/_literate/EX-boston-flux/tutorial.jl
+++ b/_literate/EX-boston-flux/tutorial.jl
@@ -7,7 +7,11 @@ end;
 
 # **Main author**: Ayush Shridhar (ayush-1506).
 
+
+# @@dropdown
 # ## Getting started
+# @@
+# @@dropdown-content
 
 import MLJFlux
 import MLJ
@@ -143,7 +147,13 @@ savefig(joinpath(@OUTPUT, "EX-boston-flux-g1.svg")) # hide
 
 # \figalt{BostonFlux1}{EX-boston-flux-g1.svg}
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Tuning
+# @@
+# @@dropdown-content
 
 # As mentioned above, `nnregressor` can act like any other MLJ model. Let's try to tune the
 # batch_size parameter.
@@ -162,3 +172,6 @@ MLJ.fit!(m)
 # The best value is:
 
 MLJ.fitted_params(m).best_model.batch_size
+
+# ‎
+# @@

--- a/_literate/EX-boston-lgbm/tutorial.jl
+++ b/_literate/EX-boston-lgbm/tutorial.jl
@@ -7,7 +7,11 @@ end;
 
 # **Main author**: Yaqub Alwan (IQVIA).
 #
+
+# @@dropdown
 # ## Getting started
+# @@
+# @@dropdown-content
 
 using MLJ
 using PrettyPrinting
@@ -136,3 +140,6 @@ rms_score = round(rms(predictions, targets[test, 1]), sigdigits=4)
 @show rms_score
 
 PyPlot.close_figs() # hide
+
+# ‎
+# @@

--- a/_literate/EX-breastcancer/tutorial.jl
+++ b/_literate/EX-breastcancer/tutorial.jl
@@ -5,11 +5,21 @@ macro OUTPUT()
     return isdefined(Main, :Franklin) ? Franklin.OUT_PATH[] : "/tmp/"
 end;
 
+
+# @@dropdown
 # ## Introduction
+# @@
+# @@dropdown-content
 # This tutorial covers the concepts of iterative model selection on the popular ["Breast Cancer Wisconsin (Diagnostic) Data Set"](https://archive.ics.uci.edu/ml/datasets/Breast+Cancer+Wisconsin+(Diagnostic))
 # from the UCI archives. The tutorial also covers basic data preprocessing and usage of MLJ Scientific Types.
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Loading the relevant packages
+# @@
+# @@dropdown-content
 # For a guide to package intsllation in Julia please refer this [link](https://docs.julialang.org/en/v1/stdlib/Pkg/) taken directly from Juliav1 documentation
 using UrlDownload
 using DataFrames
@@ -22,14 +32,30 @@ MLJ.color_off(); # hide
 # Inititalizing a global random seed which we'll use throughout the code to maintain consistency in results
 RANDOM_SEED = 42;
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Downloading and loading the data
+# @@
+# @@dropdown-content
 # Using the package UrlDownload.jl, we can capture the data from the given link using the below commands
 url = "https://archive.ics.uci.edu/ml/machine-learning-databases/breast-cancer-wisconsin/wdbc.data";
 feature_names = ["ID", "Class", "mean radius", "mean texture", "mean perimeter", "mean area", "mean smoothness", "mean compactness", "mean concavity", "mean concave points", "mean symmetry", "mean fractal dimension", "radius error", "texture error", "perimeter error", "area error", "smoothness error", "compactness error", "concavity error", "concave points error", "symmetry error", "fractal dimension error", "worst radius", "worst texture", "worst perimeter", "worst area", "worst smoothness", "worst compactness", "worst concavity", "worst concave points", "worst symmetry", "worst fractal dimension"]
 data = urldownload(url, true, format = :CSV, header = feature_names);
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Exploring the obtained data
+# @@
+# @@dropdown-content
+
+# @@dropdown
 # ### Inspecting the class variable
+# @@
+# @@dropdown-content
 figure(figsize=(8, 6))
 hist(data.Class)
 xlabel("Classes")
@@ -38,7 +64,13 @@ plt.savefig(joinpath(@OUTPUT, "Target_class.svg")); # hide
 
 # \figalt{Distribution of target classes}{Target_class.svg}
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Inspecting the feature set
+# @@
+# @@dropdown-content
 df = DataFrame(data)[:, 2:end];
 
 # Printing the 1st 10 rows so as to get a visual idea about the type of data we're dealing with
@@ -55,31 +87,68 @@ pprint(schema(df))
 # As the target variable is 'Textual' in nature, we'll have to change it to a more appropriate scientific type. Using the __coerce()__ method, let's change it to an OrderedFactor.
 coerce!(df, :Class => OrderedFactor{2});
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Unpacking the values
+# @@
+# @@dropdown-content
 # Now that our data is fully processed, we can separate the target variable 'y' from the feature set 'X' using the __unpack()__ method.
 y, X = unpack(df, ==(:Class),name->true, rng = RANDOM_SEED);
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Standardizing the "feature set"
+# @@
+# @@dropdown-content
 # Now that our feature set is separated from the target variable, we can use the __Standardizer()__ worklow to obtain to standadrize our feature set 'X'.
 transformer_instance = Standardizer()
 transformer_model = machine(transformer_instance, X)
 fit!(transformer_model)
 X = MLJ.transform(transformer_model, X);
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Train-test split
+# @@
+# @@dropdown-content
 # After feature scaling, our data is ready to put into a Machine Learning model for classification! Using 80% of data for training, we can perform a train-test split using the __partition()__ method.
 train, test = partition(eachindex(y), 0.8, shuffle=true, rng=RANDOM_SEED);
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Model compatibility
+# @@
+# @@dropdown-content
 # Now that we have separate training and testing set, let's see the models compatible with our data!
 for m in models(matching(X, y))
     println("Model name = ",m.name,", ","Prediction type = ",m.prediction_type,", ","Package name = ",m.package_name);
 end
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Analyzing the performance of different models
+# @@
+# @@dropdown-content
 # Thats a lot of models for our data! To narrow it down, lets analyze the performance of "probabilistic classifiers" from the "ScikitLearn" package.
 
+
+# @@dropdown
 # ### Creating various empty vectors for our analysis
+# @@
+# @@dropdown-content
 # - __model_names__ captures the names of the models being iterated
 # - __loss_acc captures__ the value of the model accuracy on the test set
 # - __loss_ce captures__ the values of the Cross-entropy loss on the test set
@@ -89,7 +158,13 @@ loss_acc=[];
 loss_ce=[];
 loss_f1=[];
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Collecting data for analysis
+# @@
+# @@dropdown-content
 figure(figsize=(8, 6))
 for m in models(matching(X, y))
     if m.prediction_type==Symbol("probabilistic") && m.package_name=="ScikitLearn" && m.name!="LogisticCVClassifier"
@@ -132,7 +207,13 @@ title("ROC curve")
 plt.savefig(joinpath(@OUTPUT, "breastcancer_auc_curve.svg")) # hide
 # \figalt{ROC-AUC Curve}{breastcancer_auc_curve.svg}
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Analyzing models
+# @@
+# @@dropdown-content
 # Let's collect the data in form a dataframe for a more precise analysis
 model_info=DataFrame(ModelName=model_names,Accuracy=loss_acc,CrossEntropyLoss=loss_ce,F1Score=loss_f1);
 # Now, let's sort the data on basis of the Cross-entropy loss
@@ -143,3 +224,9 @@ pprint(sort!(model_info,[:CrossEntropyLoss]));
 # # Conclusion
 # This article covered iterative feature selection on the Breast cancer classification dataset. In this tutorial, we only analyzed the __ScikitLearn__
 # models so as to keep the flow of the content precise, but the same workflow can be applied to any compatible model in the __MLJ__ family.
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/EX-crabs-xgb/tutorial.jl
+++ b/_literate/EX-crabs-xgb/tutorial.jl
@@ -7,7 +7,11 @@ end;
 
 # This example is inspired from [this post](https://www.analyticsvidhya.com/blog/2016/03/complete-guide-parameter-tuning-xgboost-with-codes-python/) showing how to use XGBoost.
 #
+
+# @@dropdown
 # ## First steps
+# @@
+# @@dropdown-content
 #
 # Again, the crabs dataset is so common that there is a  simple load function for it:
 
@@ -50,7 +54,13 @@ countmap(y[train]) |> pprint
 
 # which is pretty balanced. You could check the same on the test set and full set and the same comment would still hold.
 #
+
+# ‎
+# @@
+# @@dropdown
 # ## XGBoost machine
+# @@
+# @@dropdown-content
 #
 # Wrap a machine around an XGBoost model (XGB) and the data:
 
@@ -79,7 +89,11 @@ savefig(joinpath(@OUTPUT, "EX-crabs-xgb-curve1.svg")) # hide
 
 xgb.num_round = 200;
 
+
+# @@dropdown
 # ### More tuning (1)
+# @@
+# @@dropdown-content
 #
 # Let's now tune the maximum depth of each tree and the minimum child weight in the boosting.
 
@@ -119,7 +133,13 @@ xgb = fitted_params(mtm).best_model
 @show xgb.max_depth
 @show xgb.min_child_weight
 
+
+# ‎
+# @@
+# @@dropdown
 # ### More tuning (2)
+# @@
+# @@dropdown-content
 #
 # Let's examine the effect of `gamma`:
 
@@ -133,7 +153,13 @@ curve = learning_curve!(xgbm, range=r, resolution=30,
 @show round(minimum(curve.measurements), sigdigits=3)
 @show round(maximum(curve.measurements), sigdigits=3)
 
+
+# ‎
+# @@
+# @@dropdown
 # ### More tuning (3)
+# @@
+# @@dropdown-content
 #
 # Let's examine the effect of `subsample` and `colsample_bytree`:
 
@@ -178,3 +204,9 @@ xgb = fitted_params(mtm).best_model
 PyPlot.close_figs() # hide
 ŷ = predict_mode(mtm, rows=test)
 round(accuracy(ŷ, y[test]), sigdigits=3)
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/EX-horse/tutorial.jl
+++ b/_literate/EX-horse/tutorial.jl
@@ -2,13 +2,21 @@ using Pkg # hideall
 Pkg.activate("_literate/EX-horse/Project.toml")
 Pkg.update()
 
+
+# @@dropdown
 # ## Initial data processing
+# @@
+# @@dropdown-content
 #
 # In this example, we consider the [UCI "horse colic" dataset](http://archive.ics.uci.edu/ml/datasets/Horse+Colic)
 #
 # This is a reasonably messy classification problem with missing values etc and so some work should be expected in the feature processing.
 #
+
+# @@dropdown
 # ### Getting the data
+# @@
+# @@dropdown-content
 #
 # The data is pre-split in training and testing and we will keep it as such
 
@@ -38,7 +46,13 @@ data_test  = CSV.read(req2.body, DataFrame; csv_opts...)
 @show size(data_train)
 @show size(data_test)
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Inspecting columns
+# @@
+# @@dropdown-content
 #
 # To simplify the analysis, we will drop the columns `Lesion *` as they would need specific re-encoding which would distract us a bit.
 
@@ -87,7 +101,13 @@ datac = select!(datac, Not(:hospital_number));
 
 datac = coerce(datac, autotype(datac, rules=(:discrete_to_continuous,)));
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Dealing with missing values
+# @@
+# @@dropdown-content
 #
 # There's quite a lot of missing values, in this tutorial we'll be a bit rough in how we deal with them applying the following rules of thumb:
 #
@@ -131,7 +151,16 @@ y, X = unpack(datac, ==(:outcome), name->true);
 X = coerce(X, autotype(X, :discrete_to_continuous));
 
 #
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## A baseline model
+# @@
+# @@dropdown-content
 #
 # Let's define a first sensible model and get a baseline, basic steps are:
 # - one-hot-encode the categoricals
@@ -188,7 +217,13 @@ println(rpad("MNC mcr:", 10), round(mcr, sigdigits=3))
 
 # We've probably reached the limit of a simple linear model.
 #
+
+# ‎
+# @@
+# @@dropdown
 # ## Trying another model
+# @@
+# @@dropdown-content
 #
 # There are lots of categoricals, so maybe  it's just better to use something that deals well with that like a tree-based classifier.
 
@@ -205,3 +240,6 @@ misclassification_rate(mode.(ŷ), ytrain)
 # a significantly better misclassification rate.
 #
 # We could investigate more, do more tuning etc, but the key points of this tutorial was to show how to handle data with missing values.
+
+# ‎
+# @@

--- a/_literate/EX-housekingcounty/tutorial.jl
+++ b/_literate/EX-housekingcounty/tutorial.jl
@@ -5,11 +5,19 @@ macro OUTPUT()
     return isdefined(Main, :Franklin) ? Franklin.OUT_PATH[] : "/tmp/"
 end;
 
+
+# @@dropdown
 # ## Getting started
+# @@
+# @@dropdown-content
 #
 # This tutorial is adapted from [the corresponding MLR3 tutorial](https://mlr3gallery.mlr-org.com/posts/2020-01-30-house-prices-in-king-county/).
 #
+
+# @@dropdown
 # ### Loading and  preparing the data
+# @@
+# @@dropdown-content
 
 using MLJ
 using PrettyPrinting
@@ -63,7 +71,13 @@ df.price = df.price ./ 1000;
 
 select!(df, Not([:yr_renovated, :sqft_basement, :zipcode]));
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Basic data visualisation
+# @@
+# @@dropdown-content
 #
 # Let's plot a basic histogram of the prices to get an idea for the distribution:
 
@@ -94,7 +108,16 @@ plt.savefig(joinpath(@OUTPUT, "hist_price2.svg")) # hide
 #
 # Likewise, this could be done to verify that `condition`, `waterfront` etc are important features.
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Fitting a first model
+# @@
+# @@dropdown-content
 
 DTR = @load DecisionTreeRegressor pkg=DecisionTree
 
@@ -110,7 +133,11 @@ rms(y[test], MLJ.predict(tree, rows=test))
 
 # Let's try to do better.
 
+
+# @@dropdown
 # ### Random forest model
+# @@
+# @@dropdown-content
 
 # We might be able to improve upon the RMSE using more powerful learners.
 
@@ -134,7 +161,13 @@ cv3 = CV(; nfolds=3)
 res = evaluate(rf_mdl, X, y, resampling=CV(shuffle=true),
                measure=rms, verbosity=0)
 
+
+# ‎
+# @@
+# @@dropdown
 # ### GBM
+# @@
+# @@dropdown-content
 #
 # Let's try a different kind of model: Gradient Boosted Decision Trees from the package xgboost and we'll try to tune it too.
 
@@ -168,3 +201,9 @@ rms(y[test], MLJ.predict(mtm, rows=test))
 #
 
 PyPlot.close_figs() # hide
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/EX-powergen/tutorial.jl
+++ b/_literate/EX-powergen/tutorial.jl
@@ -7,7 +7,11 @@ end;
 
 # **Main author**: [Geoffroy Dolphin](https://github.com/gd1989)
 #
+
+# @@dropdown
 # ## Initial data processing
+# @@
+# @@dropdown-content
 # In this tutorial we are fitting solar and wind power generation output for Germany using weather data.
 # We focus on the use of a simple linear estimator. Let's load the required packages to get started.
 
@@ -102,7 +106,11 @@ describe(data, :mean, :median, :nmissing)
 # Note that the `describe()` function provides you with information about missing values for each of the columns.
 # Fortunately, there are none.
 #
+
+# @@dropdown
 # ### Adjusting the scientific types
+# @@
+# @@dropdown-content
 #
 # Let's check the default scientific type that's currently associated with the data features:
 
@@ -120,7 +128,16 @@ schema(data)
 # We're now ready to go!
 
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Exploratory Data Analysis
+# @@
+# @@dropdown-content
 
 # To get a better understanding of our targets, let's plot their respective distributions.
 
@@ -207,7 +224,13 @@ savefig(joinpath(@OUTPUT, "wind_scatter.png"), bbox_inches="tight") # hide
 
 # As expected, solar power generation shows a strong relationship to solar irradiance while wind power generation denotes a strong relationship to wind speed.
 #
+
+# ‎
+# @@
+# @@dropdown
 # ## Models
+# @@
+# @@dropdown-content
 #
 # Let's fit a linear regression to our data.
 # We focus on fitting the wind power generation but the same procedure could be applied for the solar power generation (a good exercise!).
@@ -225,7 +248,11 @@ linReg = LinearRegressor()
 m_linReg = machine(linReg, X, y_wind)
 fit!(m_linReg, rows=train);
 
+
+# @@dropdown
 # ### Model evaluation
+# @@
+# @@dropdown-content
 #
 # We've now fitted the model for wind power generation (`Wind_gen`).
 # Let's use it to predict values over the test set and investigate the performance:
@@ -281,3 +308,9 @@ savefig(joinpath(@OUTPUT, "hist_residuals.svg")) # hide
 # \figalt{Histogram of the residuals}{hist_residuals.svg}
 
 # We leave it at that for now, I hope you found this tutorial interesting.
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/EX-telco/tutorial.jl
+++ b/_literate/EX-telco/tutorial.jl
@@ -38,7 +38,11 @@ end;
 # **Time.** Between two and three hours, first time through.
 
 
+
+# @@dropdown
 # ## Summary of methods and types introduced
+# @@
+# @@dropdown-content
 
 # |code   | purpose|
 # |:-------|:-------------------------------------------------------|
@@ -76,7 +80,13 @@ end;
 # | `TunedModel(model=..., tuning=..., options...)` | wrap the supervised `model` in specified `tuning` strategy|
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Warm up: Building a model for the iris dataset
+# @@
+# @@dropdown-content
 
 # Before turning to the Telco Customer Churn dataset, we very quickly
 # build a predictive model for Fisher's well-known iris data set, as way of
@@ -159,7 +169,13 @@ yhat[2]
 # We now turn to the Telco dataset.
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Getting the Telco data
+# @@
+# @@dropdown-content
 
 import DataFrames
 
@@ -179,7 +195,13 @@ first(df0, 4)
 # two-dimensional data in MLJ.
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Type coercion
+# @@
+# @@dropdown-content
 
 # *Introduces:* `scitype`, `schema`, `coerce`
 
@@ -242,7 +264,13 @@ levels(df0.Churn) # to check order
 schema(df0) |> DataFrames.DataFrame
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Preparing a holdout set for final testing
+# @@
+# @@dropdown-content
 
 # *Introduces:* `partition`
 
@@ -259,7 +287,13 @@ df, df_test, df_dumped = partition(df0, 0.07, 0.03, # in ratios 7:3:90
 # `df, df_test = partition(df0, 0.7, rng=123)`.
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Splitting data into target and features
+# @@
+# @@dropdown-content
 
 # *Introduces:* `unpack`
 
@@ -280,7 +314,13 @@ intersect([:Churn, :customerID], schema(X).names)
 
 ytest, Xtest = unpack(df_test, ==(:Churn), !=(:customerID));
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Loading a model and checking type requirements
+# @@
+# @@dropdown-content
 
 # *Introduces:* `@load`, `input_scitype`, `target_scitype`
 
@@ -315,7 +355,13 @@ scitype(X) <: input_scitype(booster)
 # So we need categorical feature encoding, discussed next.
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Building a model pipeline to incorporate feature encoding
+# @@
+# @@dropdown-content
 
 # *Introduces:* `ContinuousEncoder`, pipeline operator `|>`
 
@@ -343,7 +389,13 @@ pipe = ContinuousEncoder() |> booster
 pipe.evo_tree_classifier.max_depth
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Evaluating the pipeline model's performance
+# @@
+# @@dropdown-content
 
 # *Introduces:* `measures` (function), **measures:** `brier_loss`,
 #  `auc`, `accuracy`; `machine`, `fit!`, `predict`, `fitted_params`,
@@ -374,7 +426,11 @@ measures("Brier")
 # the ROC curve) and `accuracy`.
 
 
+
+# @@dropdown
 # ### Evaluating by hand (with a holdout set)
+# @@
+# @@dropdown-content
 
 # Our pipeline model can be trained just like the decision tree model
 # we built for the iris data set. Binding all non-test data to the
@@ -452,7 +508,13 @@ savefig(joinpath(@OUTPUT, "EX-telco-roc.svg")) # hide
 
 # \fig{EX-telco-roc.svg}
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Automated performance evaluation (more typical workflow)
+# @@
+# @@dropdown-content
 
 # We can also get performance estimates with a single call to the
 # `evaluate` function, which also allows for more complicated
@@ -500,7 +562,16 @@ end
 confidence_intervals_basic_model = confidence_intervals(e_pipe)
 
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Filtering out unimportant features
+# @@
+# @@dropdown-content
 
 # *Introduces:* `FeatureSelector`
 
@@ -513,7 +584,13 @@ pipe2 = ContinuousEncoder() |>
     FeatureSelector(features=unimportant_features, ignore=true) |> booster
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Wrapping our iterative model in control strategies
+# @@
+# @@dropdown-content
 
 # *Introduces:* **control strategies:** `Step`, `NumberSinceBest`, `TimeLimit`,
 # `InvalidValue`, **model wrapper** `IteratedModel`, **resampling strategy:** `Holdout`
@@ -572,7 +649,13 @@ fit!(mach_iterated_pipe);
 #   data using the number of iterations determined in the first step. Calling `predict` on `mach_iterated_pipe` means using the learned parameters of the second step.
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Hyper-parameter optimization (model tuning)
+# @@
+# @@dropdown-content
 
 # *Introduces:* `range`, **model wrapper** `TunedModel`, `RandomSearch`
 
@@ -687,7 +770,13 @@ savefig(joinpath(@OUTPUT, "EX-telco-tuning.svg")) # hide
 # \fig{EX-telco-tuning.svg}
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Saving our model
+# @@
+# @@dropdown-content
 
 # *Introduces:* `MLJ.save`
 
@@ -702,7 +791,13 @@ MLJ.save("tuned_iterated_pipe.jls", mach_tuned_iterated_pipe)
 
 # We'll deserialize this in "Testing the final model" below.
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Final performance estimate
+# @@
+# @@dropdown-content
 
 # Finally, to get an even more accurate estimate of performance, we
 # can evaluate our model using stratified cross-validation and all the
@@ -731,7 +826,13 @@ confidence_intervals_basic_model
 # hyper-parameters do a pretty good job.
 
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Testing the final model
+# @@
+# @@dropdown-content
 
 # We now determine the performance of our model on our
 # lock-and-throw-away-the-key holdout set. To demonstrate
@@ -771,3 +872,6 @@ print(
 )
 
 rm("tuned_iterated_pipe.jls") # hide
+
+# ‎
+# @@

--- a/_literate/EX-wine/tutorial.jl
+++ b/_literate/EX-wine/tutorial.jl
@@ -5,13 +5,21 @@ macro OUTPUT()
     return isdefined(Main, :Franklin) ? Franklin.OUT_PATH[] : "/tmp/"
 end;
 
+
+# @@dropdown
 # ## Initial data processing
+# @@
+# @@dropdown-content
 #
 # In this example, we consider the [UCI "wine" dataset](http://archive.ics.uci.edu/ml/datasets/wine)
 #
 # > These data are the results of a chemical analysis of wines grown in the same region in Italy but derived from three different cultivars. The analysis determined the quantities of 13 constituents found in each of the three types of wines.
 #
+
+# @@dropdown
 # ### Getting the data
+# @@
+# @@dropdown-content
 #
 # Let's download the data thanks to the [UrlDownload.jl](https://github.com/Arkoniak/UrlDownload.jl) package and load it into a DataFrame:
 
@@ -41,7 +49,13 @@ describe(df)
 
 y, X = unpack(df, ==(:Class));
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Setting the scientific type
+# @@
+# @@dropdown-content
 #
 # Let's explore the scientific type attributed by default to the target and the features
 
@@ -83,7 +97,16 @@ describe(Xc, :mean, :std)
 #
 # **Note**: to complete such a first step, one could explore histograms of the various features for instance, check that there is enough variation among the continuous features and that there does not seem to be problems in the encoding, we cut this out to shorten the tutorial. We could also have checked that the data is balanced.
 #
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Getting a baseline
+# @@
+# @@dropdown-content
 #
 # It's a multiclass classification problem with continuous inputs so a sensible start is  to test two very simple classifiers to get a baseline.
 # We'll train two simple pipelines:
@@ -133,7 +156,13 @@ println(rpad("MNC mcr:", 10), round(mcr_m, sigdigits=3))
 # So here we have done no hyperparameter training and already have a misclassification rate below 5%.
 # Clearly the problem is not very difficult.
 #
+
+# ‎
+# @@
+# @@dropdown
 # ## Visualising the classes
+# @@
+# @@dropdown-content
 #
 # One way to get intuition for why the dataset is so easy to classify is to project it onto a 2D space using the PCA and display the two classes to see if they are well separated; we use the arrow-syntax here (if you're on Julia <= 1.2, use the commented-out lines as you won't be able to use the arrow-syntax)
 
@@ -179,3 +208,6 @@ println(rpad("MNC mcr:", 10), round(perf_m, sigdigits=3))
 
 # Pretty good for so little work!
 PyPlot.close_figs() # hide
+
+# ‎
+# @@

--- a/_literate/ISL-lab-10/tutorial.jl
+++ b/_literate/ISL-lab-10/tutorial.jl
@@ -5,7 +5,11 @@ macro OUTPUT()
     return isdefined(Main, :Franklin) ? Franklin.OUT_PATH[] : "/tmp/"
 end;
 
+
+# @@dropdown
 # ## Getting started
+# @@
+# @@dropdown-content
 
 using MLJ
 import RDatasets: dataset
@@ -25,7 +29,13 @@ describe(data, :mean, :std)
 X = select(data, Not(:State))
 X = coerce(X, :UrbanPop=>Continuous, :Assault=>Continuous);
 
+
+# ‎
+# @@
+# @@dropdown
 # ## PCA pipeline
+# @@
+# @@dropdown-content
 #
 # PCA is usually best done after standardization but we won't do it here:
 
@@ -48,7 +58,13 @@ cumsum(r.principalvars ./ r.tvar)
 
 # In the second line we look at the explained variance with 1 then 2 PCA features and it seems that with 2 we almost completely recover all of the variance.
 
+
+# ‎
+# @@
+# @@dropdown
 # ## More interesting data...
+# @@
+# @@dropdown-content
 
 # Instead of just playing with toy data, let's load the orange juice data and extract only the columns corresponding to price data:
 
@@ -61,7 +77,11 @@ feature_names = [
 
 X = select(data, feature_names);
 
+
+# @@dropdown
 # ### PCA pipeline
+# @@
+# @@dropdown-content
 
 Random.seed!(1515)
 
@@ -99,7 +119,13 @@ savefig(joinpath(@OUTPUT, "ISL-lab-10-g1.svg")) # hide
 
 # So 4 PCA features are enough to recover most of the variance.
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Clustering
+# @@
+# @@dropdown-content
 
 Random.seed!(1515)
 
@@ -135,3 +161,9 @@ savefig(joinpath(@OUTPUT, "ISL-lab-10-cluster.svg")) # hide
 
 # \fig{ISL-lab-10-cluster.svg}
 PyPlot.close_figs() # hide
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/ISL-lab-2/tutorial.jl
+++ b/_literate/ISL-lab-2/tutorial.jl
@@ -5,7 +5,11 @@ macro OUTPUT()
     return isdefined(Main, :Franklin) ? Franklin.OUT_PATH[] : "/tmp/"
 end;
 
+
+# @@dropdown
 # ## Basic commands
+# @@
+# @@dropdown-content
 #
 # This is a very brief and rough primer if you're new to Julia and wondering how to do simple things that are relevant for data analysis.
 #
@@ -73,7 +77,13 @@ X = [1 2; 3 4; 5 6]
 
 size(X)
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Loading data
+# @@
+# @@dropdown-content
 #
 # There are many ways to load data in Julia, one convenient one is via the [`CSV`](https://github.com/JuliaData/CSV.jl) package.
 
@@ -119,7 +129,13 @@ mpg |> mean
 # * the [`DataFrames.jl` docs](http://juliadata.github.io/DataFrames.jl/latest/)
 # * the [`StatsBases.jl` docs](https://juliastats.org/StatsBase.jl/latest/)
 #
+
+# ‎
+# @@
+# @@dropdown
 # ## Plotting data
+# @@
+# @@dropdown-content
 #
 # There are multiple libraries that can be used to  plot things in Julia:
 #
@@ -141,3 +157,6 @@ savefig(joinpath(@OUTPUT, "ISL-lab-2-mpg.svg")) # hide
 
 # \figalt{Simple plot}{ISL-lab-2-mpg.svg}
 PyPlot.close_figs() # hide
+
+# ‎
+# @@

--- a/_literate/ISL-lab-3/tutorial.jl
+++ b/_literate/ISL-lab-3/tutorial.jl
@@ -5,7 +5,11 @@ macro OUTPUT()
     return isdefined(Main, :Franklin) ? Franklin.OUT_PATH[] : "/tmp/"
 end;
 
+
+# @@dropdown
 # ## Simple linear regression
+# @@
+# @@dropdown-content
 #
 # `MLJ` essentially serves as a unified path to many existing Julia packages each of which provides their own functionalities and models, with their own conventions.
 #
@@ -111,7 +115,13 @@ savefig(joinpath(@OUTPUT, "ISL-lab-3-res2.svg")) # hide
 
 # \figalt{Histogram of the residuals}{ISL-lab-3-res2.svg}
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Interaction and transformation
+# @@
+# @@dropdown-content
 #
 # Let's say we want to also consider an interaction term of `lstat` and `age` taken together.
 # To do this, just create a new dataframe with an additional column corresponding to the interaction term:
@@ -152,3 +162,6 @@ savefig(joinpath(@OUTPUT, "ISL-lab-3-lreg.svg")) # hide
 
 # \figalt{Polynomial regression}{ISL-lab-3-lreg.svg}
 PyPlot.close_figs() # hide
+
+# ‎
+# @@

--- a/_literate/ISL-lab-4/tutorial.jl
+++ b/_literate/ISL-lab-4/tutorial.jl
@@ -5,7 +5,11 @@ macro OUTPUT()
     return isdefined(Main, :Franklin) ? Franklin.OUT_PATH[] : "/tmp/"
 end;
 
+
+# @@dropdown
 # ## Stock market data
+# @@
+# @@dropdown-content
 #
 # Let's load the usual packages and the data
 
@@ -54,7 +58,11 @@ savefig(joinpath(@OUTPUT, "ISL-lab-4-volume.svg")) # hide
 
 # \figalt{volume}{ISL-lab-4-volume.svg}
 
+
+# @@dropdown
 # ### Logistic Regression
+# @@
+# @@dropdown-content
 #
 # We will now try to train models; the target `:Direction` has two classes: `Up` and `Down`; it needs to be interpreted as a categorical object, and we will mark it as a _ordered factor_ to specify that 'Up' is positive and 'Down' negative (for the confusion matrix later):
 
@@ -148,7 +156,13 @@ ŷ |> pprint
 
 mode.(ŷ)
 
+
+# ‎
+# @@
+# @@dropdown
 # ### LDA
+# @@
+# @@dropdown-content
 #
 # Let's do a similar thing but with a LDA model this time:
 
@@ -172,7 +186,13 @@ ŷ = predict_mode(classif, rows=test)
 
 accuracy(ŷ, y[test]) |> r3
 
+
+# ‎
+# @@
+# @@dropdown
 # ### QDA
+# @@
+# @@dropdown-content
 #
 # Bayesian QDA is available via ScikitLearn:
 
@@ -186,7 +206,13 @@ ŷ = predict_mode(classif, rows=test)
 
 accuracy(ŷ, y[test]) |> r3
 
+
+# ‎
+# @@
+# @@dropdown
 # ### KNN
+# @@
+# @@dropdown-content
 #
 # We can use K-Nearest Neighbors models via the [`NearestNeighbors`](https://github.com/KristofferC/NearestNeighbors.jl) package:
 
@@ -207,7 +233,16 @@ accuracy(ŷ, y[test]) |> r3
 
 # A bit better but not hugely so.
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Caravan insurance data
+# @@
+# @@dropdown-content
 #
 # The caravan dataset is part of ISLR as well:
 
@@ -278,7 +313,11 @@ ŷ = predict_mode(classif, rows=test)
 
 accuracy(ŷ, y[test]) |> r3
 
+
+# @@dropdown
 # ### ROC and AUC
+# @@
+# @@dropdown-content
 #
 # Since we have a probabilistic classifier, we can also check metrics that take _scores_ into account such as the area under the ROC curve (AUC):
 
@@ -302,3 +341,9 @@ savefig(joinpath(@OUTPUT, "ISL-lab-4-roc.svg")) # hide
 
 # \figalt{ROC}{ISL-lab-4-roc.svg}
 PyPlot.close_figs() # hide
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/_literate/ISL-lab-5/tutorial.jl
+++ b/_literate/ISL-lab-5/tutorial.jl
@@ -5,7 +5,11 @@ macro OUTPUT()
     return isdefined(Main, :Franklin) ? Franklin.OUT_PATH[] : "/tmp/"
 end;
 
+
+# @@dropdown
 # ## Getting started
+# @@
+# @@dropdown-content
 
 using MLJ
 import RDatasets: dataset
@@ -17,7 +21,11 @@ train, test = partition(eachindex(y), 0.5, shuffle=true, rng=444);
 
 # Note the use of `rng=` to seed the shuffling of indices so that the results are reproducible.
 
+
+# @@dropdown
 # ### Polynomial regression
+# @@
+# @@dropdown-content
 #
 
 LR = @load LinearRegressor pkg=MLJLinearModels
@@ -123,7 +131,16 @@ savefig(joinpath(@OUTPUT, "ISL-lab-5-g3.svg")) # hide
 
 # \figalt{1st, 2nd and 3d order fit}{ISL-lab-5-g3.svg}
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## K-Folds Cross Validation
+# @@
+# @@dropdown-content
 #
 # Let's crossvalidate over the degree of the  polynomial.
 #
@@ -170,7 +187,16 @@ savefig(joinpath(@OUTPUT, "ISL-lab-5-g4.svg")) # hide
 
 # \figalt{5th order fit}{ISL-lab-5-g4.svg}
 
+
+# ‎
+# @@
+# @@dropdown
 # ## The Bootstrap
+# @@
+# @@dropdown-content
 #
 # _Bootstrapping is not currently supported in MLJ._
 PyPlot.close_figs() # hide
+
+# ‎
+# @@

--- a/_literate/ISL-lab-6b/tutorial.jl
+++ b/_literate/ISL-lab-6b/tutorial.jl
@@ -8,7 +8,11 @@ end;
 # In this tutorial, we are exploring the application of Ridge and Lasso
 # regression to the Hitters R dataset.
 #
+
+# @@dropdown
 # ## Getting started
+# @@
+# @@dropdown-content
 
 using MLJ
 import RDatasets: dataset
@@ -80,7 +84,11 @@ savefig(joinpath(@OUTPUT, "ISL-lab-6-g2.svg")) # hide
 
 # \figalt{Distribution of salary}{ISL-lab-6-g2.svg}
 #
+
+# @@dropdown
 # ### Data preparation
+# @@
+# @@dropdown-content
 #
 # Most features are currently encoded as integers but we will consider them as continuous.
 # To coerce `int` features to `Float`, we nest the `autotype` function in the `coerce` function.
@@ -92,8 +100,21 @@ scitype(Xc)
 
 # There're a few features that are categorical which we'll one-hot-encode.
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Ridge pipeline
+# @@
+# @@dropdown-content
+
+# @@dropdown
 # ### Baseline
+# @@
+# @@dropdown-content
 #
 # Let's first fit a simple pipeline with a standardizer, a one-hot-encoder and a basic linear regression:
 
@@ -140,7 +161,13 @@ savefig(joinpath(@OUTPUT, "ISL-lab-6-g4.svg")) # hide
 
 # \figalt{Distribution of residuals}{ISL-lab-6-g4.svg}
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Basic Ridge
+# @@
+# @@dropdown-content
 #
 # Let's now swap the linear regressor for a Ridge one without specifying the penalty (`1` by default):
 # We modify the supervised model in the pipeline directly.
@@ -152,7 +179,13 @@ round(rms(ŷ, y[test])^2, sigdigits=4)
 
 # Ok that's a bit better but surely we can do better with an appropriate selection of the hyperparameter.
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Cross validating
+# @@
+# @@dropdown-content
 
 # What penalty should you use? Let's do a simple CV to try to find out:
 
@@ -190,7 +223,16 @@ savefig(joinpath(@OUTPUT, "ISL-lab-6-g5.svg")) # hide
 #
 # You can compare that with the residuals obtained earlier.
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Lasso pipeline
+# @@
+# @@dropdown-content
 #
 # Let's do the same as above but using a Lasso model and adjusting the range a bit:
 
@@ -237,7 +279,13 @@ savefig(joinpath(@OUTPUT, "ISL-lab-6-g6.svg")) # hide
 
 # \figalt{Lasso coefficients}{ISL-lab-6-g6.svg}
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Elastic net pipeline
+# @@
+# @@dropdown-content
 
 ElasticNetRegressor = @load ElasticNetRegressor pkg=MLJLinearModels
 
@@ -258,3 +306,6 @@ round(rms(ŷ, y[test])^2, sigdigits=4)
 
 # But the simple ridge regression seems to work best here.
 PyPlot.close_figs() # hide
+
+# ‎
+# @@

--- a/_literate/ISL-lab-8/tutorial.jl
+++ b/_literate/ISL-lab-8/tutorial.jl
@@ -6,7 +6,11 @@ macro OUTPUT()
 end;
 
 
+
+# @@dropdown
 # ## Getting started
+# @@
+# @@dropdown-content
 
 using MLJ
 import RDatasets: dataset
@@ -29,7 +33,11 @@ carseats[!, :High] = High;
 X = select(carseats, Not([:Sales, :High]))
 y = carseats.High;
 
+
+# @@dropdown
 # ### Decision Tree Classifier
+# @@
+# @@dropdown-content
 
 HotTreeClf = OneHotEncoder() |> DTC()
 
@@ -53,7 +61,13 @@ misclassification_rate(ypred, y[test])
 
 # Not really...
 #
+
+# ‎
+# @@
+# @@dropdown
 # ### Tuning a DTC
+# @@
+# @@dropdown-content
 #
 # Let's try to do a bit of tuning
 
@@ -78,7 +92,13 @@ misclassification_rate(ypred, y[test])
 
 fitted_params(mtm).best_model.decision_tree_classifier
 
+
+# ‎
+# @@
+# @@dropdown
 # ### Decision Tree Regressor
+# @@
+# @@dropdown-content
 #
 
 DTR = @load DecisionTreeRegressor pkg=DecisionTree
@@ -122,7 +142,16 @@ fit!(mtm, rows=train)
 ypred = MLJ.predict(mtm, rows=test)
 round(rms(ypred, y[test]), sigdigits=3)
 
+
+# ‎
+# @@
+
+# ‎
+# @@
+# @@dropdown
 # ## Random Forest
+# @@
+# @@dropdown-content
 #
 # **Note**: the package [`DecisionTree.jl`](https://github.com/bensadeghi/DecisionTree.jl) also has a RandomForest model but it is not yet interfaced with in MLJ.
 
@@ -135,7 +164,13 @@ fit!(rf, rows=train)
 ypred = MLJ.predict(rf, rows=test)
 round(rms(ypred, y[test]), sigdigits=3)
 
+
+# ‎
+# @@
+# @@dropdown
 # ## Gradient Boosting Machine
+# @@
+# @@dropdown-content
 
 XGBR = @load XGBoostRegressor
 
@@ -147,3 +182,6 @@ ypred = MLJ.predict(xgb, rows=test)
 round(rms(ypred, y[test]), sigdigits=3)
 
 # Again we could do some tuning for this.
+
+# ‎
+# @@

--- a/_literate/ISL-lab-9/tutorial.jl
+++ b/_literate/ISL-lab-9/tutorial.jl
@@ -5,7 +5,11 @@ macro OUTPUT()
     return isdefined(Main, :Franklin) ? Franklin.OUT_PATH[] : "/tmp/"
 end;
 
+
+# @@dropdown
 # ## Getting started
+# @@
+# @@dropdown-content
 
 using MLJ
 import RDatasets: dataset
@@ -57,7 +61,11 @@ misclassification_rate(ypred, y)
 
 
 
+
+# @@dropdown
 # ### Basic tuning
+# @@
+# @@dropdown-content
 
 # As usual we could tune the model, for instance the penalty encoding the tradeoff between margin width and misclassification:
 
@@ -73,3 +81,9 @@ misclassification_rate(ypred, y)
 
 # You could also change the kernel etc.
 PyPlot.close_figs() # hide
+
+# ‎
+# @@
+
+# ‎
+# @@

--- a/assets/down-icon.svg
+++ b/assets/down-icon.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 10L12 15L17 10" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/right-icon.svg
+++ b/assets/right-icon.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 7L15 12L10 17" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/script.ipynb
+++ b/script.ipynb
@@ -1,0 +1,151 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Script to Add Collapse Functionality to All Tutorials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Julia script to loop over tutorials and modify the sections into dropdowns. It does the following:\n",
+    "\n",
+    "- Replace any `# ### .*` with the same h3 heading after wrapping with `@@dropdown...@@` and wrap next section (before next `# ## .*`) with `@@dropdown-content...@@`\n",
+    "- To handle nesting (avoid defining a section going past h2 heading) the file is first split by h2 headings then the logic above is applied\n",
+    "- To further handle nesting (have h2s collapse as well), the same logic is applied for h2s\n",
+    "- This is applied to all `tutorial.js` files found in `_literate.jl`\n",
+    "- Note that an invisible charachter `U+200E` is used due to a bug that occurs whenever a section ends with a line of code rather than raw text.\n",
+    "- The script is idempotent (won't modify a file it touched before) so it could be run after a new tutorial is added."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 164,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "introduce_dropdowns (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 164,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: both ReadableRegex and RegularExpressions export \"between\"; uses of it in module Main must be qualified\n"
+     ]
+    }
+   ],
+   "source": [
+    "using RegularExpressions\n",
+    "\n",
+    "# modify h2 or h3 headings (depending on pattern) for a single file \n",
+    "function modify_string(input, pattern)\n",
+    "    matches = eachmatch(pattern, input)\n",
+    "    modified_string = \"\"\n",
+    "    last_end = 1\n",
+    "    \n",
+    "    for match in matches\n",
+    "        modified_string *= input[last_end:match.offset-1]\n",
+    "        if match.match != \"\"\n",
+    "            if last_end == 1\n",
+    "                modified_string *= \"\\n# @@dropdown\\n$(match.match[1:end-1])\\n# @@\\n# @@dropdown-content\\n\"\n",
+    "            else\n",
+    "                modified_string *= \"\\n# ‎\\n# @@\\n# @@dropdown\\n$(match.match[1:end-1])\\n# @@\\n# @@dropdown-content\\n\"\n",
+    "            end\n",
+    "            last_end = match.offset + length(match.match)\n",
+    "        end\n",
+    "    end\n",
+    "    \n",
+    "    modified_string *= input[last_end:end]\n",
+    "    (input == modified_string && return input)\n",
+    "    return modified_string*\"\\n# ‎\\n# @@\\n\"\n",
+    "end\n",
+    "\n",
+    "# so we can split by h2s\n",
+    "function split_keeping_splitter(string, splitter)\n",
+    "    r = Regex(either( look_for(\"\", before = splitter), look_for(\"\", after = splitter)))\n",
+    "    split(string, r)\n",
+    "end\n",
+    "\n",
+    "# apply logic on h3s after splitting by h2s then apply it on h2s (introduce collapsables to a single file)\n",
+    "function introduce_dropdowns(input::AbstractString)\n",
+    "    # if the string has @@dropdown return it as is\n",
+    "    if occursin(r\"@@dropdown\", input)\n",
+    "        return input\n",
+    "    end\n",
+    "    chunks = split_keeping_splitter(input, \"# ## \")\n",
+    "    for (i, chunk) in enumerate(chunks)\n",
+    "        if chunk !=\"# ## \" \n",
+    "            chunks[i] = modify_string(chunk, r\"(# ### .*\\n)\")\n",
+    "        end\n",
+    "    end\n",
+    "    modified_string = join(chunks)\n",
+    "\n",
+    "    return modify_string(modified_string, r\"(# ## .*\\n)\")\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 163,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# apply dropdown logic to all files\n",
+    "function read_tutorials(tutorials_dir)\n",
+    "    # Ensure existence of the directory\n",
+    "    if !isdir(tutorials_dir)\n",
+    "        error(\"Directory '$tutorials_dir' does not exist.\")\n",
+    "    end\n",
+    "\n",
+    "    # Iterate over all files named \"tutorial.js\" in subdirectories\n",
+    "    for subdir in readdir(tutorials_dir)\n",
+    "        file_path = joinpath(tutorials_dir, subdir, \"tutorial.jl\")\n",
+    "        if isfile(file_path)\n",
+    "            try\n",
+    "                file = open(file_path, \"r\")\n",
+    "                content = read(file, String)\n",
+    "                close(file)\n",
+    "                file = open(file_path, \"w\")\n",
+    "                modified_content = introduce_dropdowns(content)\n",
+    "                write(file, modified_content)\n",
+    "                close(file)\n",
+    "                # Store content in the dictionary\n",
+    "            catch e\n",
+    "                throw(\"Error reading file '$file_path': $(e)\")\n",
+    "            end\n",
+    "        end\n",
+    "    end\n",
+    "end\n",
+    "\n",
+    "\n",
+    "\n",
+    "read_tutorials(\"_literate\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.10.0",
+   "language": "julia",
+   "name": "julia-1.10"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR makes use of Franklin's @@ feature and JavaScript to allow markdown files to have collapsable sections. Given any sequence of markdown elements of length two that take the form:
```
<markdown heading or list item>

<markdown>
```
Introducing the feature is possible by wrapping the sections with `@@` accordingly:
```
@@dropdown
<markdown heading or list item>
@@
@@dropdown-content
<markdown>
@@
```

The resulting UI will make it possible to use the heading/list item to show or collapse the markdown in dropdown-content. This is used in the sidebar and all tutorials.


![collapse](https://github.com/JuliaAI/DataScienceTutorials.jl/assets/49572294/45895cb1-50ce-43f2-af61-be5878056760)

Thanks for this nice package. Absolutely deserves much wider recognition.