### PR TITLE
Centralize the index and add local navigation functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,7 @@ Find the corresponding script, fix it in a PR.
 Once all that's done, the remaining things to do are to create the HTML page and a link in the appropriate location. Let's assume you wanted to add an E2E tutorial "Dinosaurs" then in the previous step you'd have `EX-dinosaurs` and you would
 
 * create a file `dinosaurs.md` in `end-to-end/` by duplicating the `end-to-end/wine.md` and changing the reference in it to `\tutorial{EX-dinosaurs}`
-* add links pointing to that tutorial
-  * in `index.md` following the template
-  * in `_layout/head.html` following the template
+* add a link pointing to that tutorial in `_libs/nav/head.js` following the template so your tutorial shows in the navigation bar
 * lastly, to make sections in your tutorial collapsible like other tutorials run the `collapse-script.jl` file via `julia collapse-script.jl`
 
 

--- a/_css/nav.css
+++ b/_css/nav.css
@@ -22,6 +22,11 @@
     display: none;
   }
 }
+
+a#home {
+  border-radius: 3rem;
+}
+
 .brand a,
 .brand a:visited {
   text-decoration: none;
@@ -115,4 +120,39 @@ nav ul li ul li a {
   border-radius: 0rem 0rem 1rem 1rem;
   background-color: #f1f1f1;
 
+}
+
+.bottom-nav-container {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 2rem;
+  margin-bottom: -2rem;
+
+}
+
+.bottom-nav {
+  background-color: #f1f1f1;
+  font-weight: 600;
+  padding: 8px 8px;
+  color: #2e2e2e;
+  border-radius: 45px;
+  outline: none;
+  text-align: center;
+  cursor: pointer;
+  transition: background-color 0.3s, color 0.3s;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-decoration: none;
+  width: 200px;
+  border: 2px solid #c1c1c1;
+}
+.bottom-nav:hover {
+  background-color: #9b59b6;
+  color: #f1f1f1;
+}
+.button-label {
+  font-size: 0.9rem;
+  font-weight: 400;
 }

--- a/_layout/foot.html
+++ b/_layout/foot.html
@@ -1,20 +1,24 @@
 <!-- CONTENT ENDS HERE -->
-      </div> <!-- end of id=main -->
-  </div> <!-- end of id=layout -->
-  <!-- for collapse functionality -->
-  <script src="/libs/collapse/collapse.js"></script>
-  <script src="/libs/pure/ui.min.js"></script>
-    <!-- navigation bar -->
-    <script src="/libs/nav/nav.js"></script>
-    <!-- responsive navigation bar -->
-    <script src="/libs/nav/responsive.js"></script>
-    <!-- landing page -->
-    <script src="/libs/landing/landing.js"></script>
-  {{ if hasmath }}
-      {{ insert foot_katex.html }}
-  {{ end }}
-  {{ if hascode }}
-      {{ insert foot_highlight.html }}
-  {{ end }}
+</div> <!-- end of id=main -->
+</div> <!-- end of id=layout -->
+<!-- for collapse functionality -->
+<script src="/libs/collapse/collapse.js"></script>
+<script src="/libs/pure/ui.min.js"></script>
+<!-- head and footer-nav -->
+<script src="/libs/nav/head.js"></script>
+<script src="/libs/nav/footer-nav.js"></script>
+<!-- landing page -->
+<script src="/libs/landing/landing.js"></script>
+<!-- navigation bar -->
+<script src="/libs/nav/nav.js"></script>
+<!-- responsive navigation bar -->
+<script src="/libs/nav/responsive.js"></script>
+{{ if hasmath }}
+{{ insert foot_katex.html }}
+{{ end }}
+{{ if hascode }}
+{{ insert foot_highlight.html }}
+{{ end }}
 </body>
+
 </html>

--- a/_layout/head.html
+++ b/_layout/head.html
@@ -183,78 +183,7 @@
       <nav>
         <div class="nav-mobile"><a id="nav-toggle" href="#!"><span></span></a></div>
         <ul class="nav-list">
-          <li>
-            <a id="home" class="main-nav-item" style="border-radius: 2rem 2rem 2rem 2rem;" href="/">Home</a>
-          </li>
-          <li>
-            <a class="main-nav-item" id="data" href="#!">Data Basics</a>
-            <ul class="nav-dropdown">
-              <li class="short-item"><a href="/data/loading/">Loading data</a></li>
-              <li class="short-item"><a href="/data/dataframe/">Data Frames</a></li>
-              <li class="short-item"><a href="/data/categorical/">Categorical Arrays</a></li>
-              <li class="short-item"><a href="/data/scitype/">Scientific Type</a></li>
-              <li class="short-item"><a href="/data/processing/">Data processing</a></li>
-            </ul>
-          </li>
-          <li>
-            <a class="main-nav-item" id="getting-started" href="#!">Getting Started</a>
-            <ul class="nav-dropdown">
-              <li>
-                <a href="/getting-started/choosing-a-model/"> Choosing a model</a>
-              </li>
-              <li>
-                <a href="/getting-started/fit-and-predict/"> Fit, predict, transform</a>
-              </li>
-              <li class="medium-item"><a href="/getting-started/model-tuning/"> Model tuning</a></li>
-              <li class="medium-item"><a href="/getting-started/ensembles/"> Ensembles</a></li>
-              <li class="medium-item"><a href="/getting-started/ensembles-2/"> Ensembles (2)</a></li>
-              <li class="medium-item"><a href="/getting-started/composing-models/"> Composing models</a></li>
-              <li class="medium-item"><a href="/getting-started/stacking/"> Stacking</a></li>
-            </ul>
-          </li>
-          <li>
-            <a class="main-nav-item" id="stats-learning" href="#!">Intro to Stats Learning</a>
-            <ul class="nav-dropdown">
-              <li class="long-item"><a href="/isl/lab-2/"> Lab 2</a></li>
-              <li class="long-item"><a href="/isl/lab-3/"> Lab 3</a></li>
-              <li class="long-item"><a href="/isl/lab-4/"> Lab 4</a></li>
-              <li class="long-item"><a href="/isl/lab-5/"> Lab 5</a></li>
-              <li class="long-item"><a href="/isl/lab-6b/"> Lab 6b</a></li>
-              <li class="long-item"><a href="/isl/lab-8/"> Lab 8</a></li>
-              <li class="long-item"><a href="/isl/lab-9/"> Lab 9</a></li>
-              <li class="long-item"><a href="/isl/lab-10/"> Lab 10</a></li>
-            </ul>
-          </li>
-          <li>
-            <a class="main-nav-item" href="#!" id="end-to-end">End to End</a>
-            <ul class="nav-dropdown">
-              <li class="long-item"><a href="/end-to-end/telco/">Telco Churn</a></li>
-              <li class="long-item"><a href="/end-to-end/AMES/"> AMES</a></li>
-              <li class="long-item"><a href="/end-to-end/wine/"> Wine</a></li>
-              <li class="long-item"><a href="/end-to-end/crabs-xgb/"> Crabs (XGB)</a></li>
-              <li class="long-item"><a href="/end-to-end/horse/"> Horse</a></li>
-              <li class="long-item"><a href="/end-to-end/HouseKingCounty/"> King County Houses</a></li>
-              <li class="long-item"><a href="/end-to-end/airfoil"> Airfoil </a></li>
-              <li class="long-item"><a href="/end-to-end/boston-lgbm"> Boston (lgbm) </a></li>
-              <li class="long-item"><a href="/end-to-end/glm/"> Using GLM.jl </a></li>
-              <li class="long-item"><a href="/end-to-end/powergen/"> Power Generation </a></li>
-              <li class="long-item"><a href="/end-to-end/boston-flux"> Boston (Flux) </a></li>
-              <li class="long-item"><a href="/end-to-end/breastcancer"> Breast Cancer</a></li>
-              <li class="long-item"><a href="/end-to-end/creditfraud">Credit Fraud</a></li>
-            </ul>
-          </li>
-          <li>
-            <a class="main-nav-item" href="#!" id="advanced">Advanced</a>
-            <ul class="nav-dropdown">
-              <li class="long-item"><a href="/advanced/ensembles-3">Ensembles (3)</a></li>
-            </ul>
-          </li>
-          <li>
-            <form id="lunrSearchForm" name="lunrSearchForm" style="margin-left: 1.5rem; margin-right: -2rem;">
-              <input class="search-input" name="q" placeholder="Search..." type="text">
-              <input type="submit" value="Search" formaction="/search/index.html" style="display:none">
-            </form>
-          </li>
+        <!-- horizontal navigation bar gets injected -->
         </ul>
       </nav>
     </div>

--- a/_layout/page_foot.html
+++ b/_layout/page_foot.html
@@ -1,5 +1,16 @@
+<div class="bottom-nav-container">
+  <a id="prev-tutorial" style="text-decoration: none"><Button class="bottom-nav">
+        <div>← Previous Tutorial</div>
+        <div id="prev-label" class="button-label"> Home</div>
+    </Button></a>
+  <a id="next-tutorial" style="text-decoration: none"><Button class="bottom-nav">
+        <div>Next Tutorial →</div>
+        <div id="next-label" class="button-label">Home</div> 
+    </Button></a>
+</div>
 <div class="page-foot">
   <div class="copyright">
-    &copy; {{ fill author }}. Last modified: {{ fill fd_mtime }}. Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a>.
+    &copy; {{ fill author }}. Last modified: {{ fill fd_mtime }}. Website built with <a
+      href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a>.
   </div>
 </div>

--- a/_libs/nav/head.js
+++ b/_libs/nav/head.js
@@ -1,0 +1,233 @@
+
+const navItems = [
+  { name: 'Home', href: '/', sections: [], sectionItemWidth: '', id: 'home' },
+  {
+    name: 'Data Basics',                                    // Category name to be shown in navigation bar
+    id: 'data',                                             // id to be manipulated with js
+    href: '#!',                                             // in case it should link anywhere
+    sections: [                                             // list items to be shown in its dropdown and where they link to
+      { name: 'Loading Data', href: '/data/loading/' },
+      { name: 'Data Frames', href: '/data/dataframe/' },
+      { name: 'Categorical Arrays', href: '/data/categorical/' },
+      { name: 'Scientific Type', href: '/data/scitype/' },
+      { name: 'Data processing', href: '/data/processing/' },
+    ],
+    sectionItemWidth: 'short-item'
+  },
+  {
+    name: 'Getting Started',
+    id: 'getting-started',
+    href: '#!',
+    sections: [
+      { name: 'Choosing a model', href: '/getting-started/choosing-a-model/' },
+      { name: 'Fit, predict, transform', href: '/getting-started/fit-and-predict/' },
+      { name: 'Model tuning', href: '/getting-started/model-tuning/' },
+      { name: 'Ensembles', href: '/getting-started/ensembles/' },
+      { name: 'Ensembles (2)', href: '/getting-started/ensembles-2/' },
+      { name: 'Composing models', href: '/getting-started/composing-models/' },
+      { name: 'Stacking', href: '/getting-started/stacking/' },
+    ],
+    sectionItemWidth: 'medium-item'
+  },
+  {
+    name: 'Intro to Stats Learning',
+    id: 'stats-learning',
+    href: '#!',
+    sections: [
+      { name: 'Lab 2', href: '/isl/lab-2/' },
+      { name: 'Lab 3', href: '/isl/lab-3/' },
+      { name: 'Lab 4', href: '/isl/lab-4/' },
+      { name: 'Lab 5', href: '/isl/lab-5/' },
+      { name: 'Lab 6b', href: '/isl/lab-6b/' },
+      { name: 'Lab 8', href: '/isl/lab-8/' },
+      { name: 'Lab 9', href: '/isl/lab-9/' },
+      { name: 'Lab 10', href: '/isl/lab-10/' },
+    ],
+    sectionItemWidth: 'long-item'
+  },
+
+  {
+    name: 'End to End',
+    id: 'end-to-end',
+    href: '#!',
+    sections: [
+      { name: 'Telco Churn', href: '/end-to-end/telco/' },
+      { name: 'AMES', href: '/end-to-end/AMES/' },
+      { name: 'Wine', href: '/end-to-end/wine/' },
+      { name: 'Crabs (XGB)', href: '/end-to-end/crabs-xgb/' },
+      { name: 'Horse', href: '/end-to-end/horse/' },
+      { name: 'King County Houses', href: '/end-to-end/HouseKingCounty/' },
+      { name: 'Airfoil', href: '/end-to-end/airfoil' },
+      { name: 'Boston (lgbm)', href: '/end-to-end/boston-lgbm' },
+      { name: 'Using GLM.jl', href: '/end-to-end/glm/' },
+      { name: 'Power Generation', href: '/end-to-end/powergen/' },
+      { name: 'Boston (Flux)', href: '/end-to-end/boston-flux' },
+      { name: 'Breast Cancer', href: '/end-to-end/breastcancer' },
+      { name: 'Credit Fraud', href: '/end-to-end/creditfraud' },
+    ],
+    sectionItemWidth: 'long-item'
+  },
+  {
+    name: 'Advanced',
+    id: 'advanced',
+    href: '#!',
+    sections: [{ name: 'Ensembles (3)', href: '/advanced/ensembles-3' }],
+    sectionItemWidth: 'medium-item'
+  },
+];
+
+const navList = document.querySelector('.nav-list');
+
+// for each object above we will call this function
+function createNavItem(item) {
+  // a nav item is an li wrapping an anchor
+  const li = document.createElement('li');
+  const link = document.createElement('a');
+  // set style, link and text content of anchor
+  link.textContent = item.name;
+  link.classList.add('main-nav-item');
+  link.href = item.href;
+  link.id = item.id;
+
+  li.appendChild(link);
+
+  // create a dropdown it item.sections is not empty
+  if (item.sections.length > 0) {
+    const dropdown = createDropDown(item.sections, item.sectionItemWidth);
+    li.appendChild(dropdown);
+  }
+
+  return li;
+}
+
+function createDropDown(sections, sectionWidth) {
+  // a dropdown is a ul wrapping a sequence of li wrapping an anchor for each item
+  const dropdown = document.createElement('ul');
+  dropdown.classList.add('nav-dropdown');
+
+  // for each section make an li wrapping an anchor
+  sections.forEach((section) => {
+    const subItem = document.createElement('li');
+    subItem.classList.add(sectionWidth)
+    const subLink = document.createElement('a');
+    subLink.textContent = section.name;
+    subLink.href = section.href;
+    subItem.appendChild(subLink);
+    dropdown.appendChild(subItem);
+  });
+
+  return dropdown;
+}
+
+navList.innerHTML = ''; // Clear existing content
+
+navItems.forEach((item) => {
+  navList.appendChild(createNavItem(item));
+});
+
+// add a final li as searchform
+searchForm = `
+  <li>
+    <form id="lunrSearchForm" name="lunrSearchForm" style="margin-left: 1.5rem; margin-right: -2rem;">
+      <input class="search-input" name="q" placeholder="Search..." type="text">
+      <input type="submit" value="Search" formaction="/search/index.html" style="display:none">
+    </form>
+  </li>`
+
+navList.innerHTML += searchForm
+
+// For the mobile navigation bar:
+function createListItem(item) {
+  return `
+    <li class="pure-menu-item">
+      <a href="${item.href}" class="pure-menu-link"><span style="padding-right:0.5rem;">•</span>${item.name}</a>
+    </li>
+  `;
+}
+
+// Function to create dropdown content
+function createDropdownContent(category) {
+  const items = category.sections.map(createListItem).join('');
+  return `
+    <div class="dropdown">
+      <li class="pure-menu-sublist-title"><strong>${category.name}</strong></li>
+    </div>
+    <div class="collapse dropdown-content">
+      <ul class="pure-menu-sublist">${items}</ul>
+    </div>
+  `;
+}
+
+function generateSidebar(navItems) {
+  const navList = document.querySelector('.pure-menu-list');
+  let navHTML = '';
+  // Home item is a special case
+  const isHomePage = window.location.pathname === '/';
+  const homeClass = isHomePage ? 'pure-menu-selected' : '';
+  navHTML += `
+    <li id="home-sidebar" class="pure-menu-item pure-menu-top-item ${homeClass}">
+      <a href="/" class="pure-menu-link"><strong>Home</strong></a>
+    </li>
+  `;
+
+  // Then comes the rest of the categories and the dropdowns
+  navItems.forEach(item => {
+    if (item.sections.length > 0) {
+      navHTML += createDropdownContent(item);
+    }
+  });
+
+  navList.innerHTML = navHTML;
+}
+
+// Call the function to generate the sidebar
+generateSidebar(navItems);
+
+
+// Flatten the nav items so we can easily iterate through them
+function flattenNavItems(items) {
+  return items.reduce((acc, item) => {
+    if (item.href != "#!") {
+      acc.push(item);
+    }
+    if (item.sections) {
+      acc.push(...flattenNavItems(item.sections));
+    }
+    return acc;
+  }, []);
+}
+
+const flatItems = flattenNavItems(navItems);
+
+// loop and roate based on clicks
+function getPreviousAndNextTutorials(currentHref) {
+  let currentIndex = flatItems.findIndex(item => (currentHref.includes(item.href) && item.href != "/"));
+  console.log(currentIndex)
+  currentIndex = currentIndex === -1 ? 0 : currentIndex;
+  const totalItems = flatItems.length;
+
+  // Calculate previous and next indices considering rotation
+  const previousIndex = (currentIndex - 1 + totalItems) % totalItems;
+  const nextIndex = (currentIndex + 1) % totalItems;
+  return {
+    previousTutorial: flatItems[previousIndex],
+    nextTutorial: flatItems[nextIndex],
+    currentIndex
+  };
+}
+
+// Update buttons based on current href
+function updateNavigationButtons(currentHref) {
+  const { previousTutorial, nextTutorial, currentIndex } = getPreviousAndNextTutorials(currentHref);
+  document.getElementById("prev-tutorial").setAttribute("href", previousTutorial.href);
+  document.getElementById("next-tutorial").setAttribute("href", nextTutorial.href);
+  document.getElementById("prev-label").innerHTML = previousTutorial.name;
+  document.getElementById("next-label").innerHTML = nextTutorial.name;
+  // if we are at home disable previous button
+  document.getElementById("prev-tutorial").style.display = currentIndex === 0 ? "none" : "block";
+  // if we are at last item disable next button
+  document.getElementById("next-tutorial").style.display = currentIndex === flatItems.length - 1 ? "none" : "block";
+}
+
+const currentHref = window.location.href;
+updateNavigationButtons(currentHref);


### PR DESCRIPTION
In a previous PR I mentioned that it's not elegant that one has to add a new tutorial to two navigation bars (and modify code instead of data in general). That along with the fact that centralizing the index as a JavaScript object would allow easy implementation of local navigation (which I felt the need for because reaching out for the navigation bar to get the next tutorial takes a little effort) were reasons that made me decide to:

- Centralize the index. It's now a JS object in `libs\nav\head.js` and any changes to it should meaningfully reflect to both navigation bars. For some reason, it wasn't easy to make the object live in its own file but we can look into this in a later PR where we also consider other parts of file organization in the repo.

<img width="983" alt="image" src="https://github.com/JuliaAI/DataScienceTutorials.jl/assets/49572294/e4539a46-06b5-4bad-8761-3201c3afc071">


- Use the centralized JS index to support for local navigation

[local.webm](https://github.com/JuliaAI/DataScienceTutorials.jl/assets/49572294/3059fcef-0c63-41e1-af3e-a8bcad63da26)

Don't worry about the undef variables shown in the video. I didn't do an appropriate serve and it surely works as confirmed on `fix-minor-plots-validation`.


